### PR TITLE
Upgrade AGP to 7.2.0-alpha01

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:7.1.0-alpha13")
+        classpath("com.android.tools.build:gradle:7.2.0-alpha01")
         classpath("com.vanniktech:gradle-maven-publish-plugin:0.18.0")
         classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.18.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31")


### PR DESCRIPTION
The `0.0.1`﻿release of the library was published with AGP 7.1.0-alpha13 which presents the artifact as incompatible when trying to consume it in a project using the newly released AGP 7.2.0-alpha01.

[Here](https://scans.gradle.com/s/nwaq7iezhz3qq) is a Gradle build scan detailing the failure encountered, and the source code to reproduce the failure can be found [here](https://github.com/msfjarvis/compose-lobsters/tree/hs/agp-bump). Building the `android` module of the linked project is enough to reproduce the bug.
