### PR TITLE
Add image loading support for JVM target

### DIFF
--- a/multiplatform-markdown-renderer/src/androidMain/kotlin/com/mikepenz/markdown/ImagePainterProvider.kt
+++ b/multiplatform-markdown-renderer/src/androidMain/kotlin/com/mikepenz/markdown/ImagePainterProvider.kt
@@ -8,6 +8,6 @@ import coil.size.OriginalSize
 
 @OptIn(ExperimentalCoilApi::class)
 @Composable
-internal actual fun imagePainter(url: String): Painter {
+internal actual fun imagePainter(url: String): Painter? {
     return rememberImagePainter(url, builder = { size(OriginalSize) })
 }

--- a/multiplatform-markdown-renderer/src/jvmMain/kotlin/com/mikepenz/markdown/ImagePainterProvider.kt
+++ b/multiplatform-markdown-renderer/src/jvmMain/kotlin/com/mikepenz/markdown/ImagePainterProvider.kt
@@ -1,11 +1,39 @@
 package com.mikepenz.markdown
 
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.runtime.*
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.skia.Image
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URL
 
 @Composable
-internal actual fun imagePainter(url: String): Painter {
-    return ColorPainter(Color.Red)
+internal actual fun imagePainter(url: String): Painter? {
+    return fetchImage(url)?.let { BitmapPainter(it) }
+}
+
+@Composable
+fun fetchImage(url: String): ImageBitmap? {
+    var image by remember(url) { mutableStateOf<ImageBitmap?>(null) }
+    LaunchedEffect(url) {
+        image = loadPicture(url)
+    }
+    return image
+}
+
+suspend fun loadPicture(url: String): ImageBitmap? = withContext(Dispatchers.IO) {
+    return@withContext runCatching {
+        val url = URL(url)
+        val connection: HttpURLConnection = url.openConnection() as HttpURLConnection
+        connection.connectTimeout = 5000
+        connection.connect()
+
+        val input: InputStream = connection.inputStream
+        Image.makeFromEncoded(input.readBytes()).toComposeImageBitmap()
+    }.getOrNull()
 }


### PR DESCRIPTION
- implement image loading for JVM target (desktop)
- resolve image url from markdown properly
- set fixed size for inline content as 180.sp x 180.sp -> open for suggestions to improve auto scaling here!