### PR TITLE
Support custom text color

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/Markdown.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/Markdown.kt
@@ -52,16 +52,17 @@ import org.intellij.markdown.parser.MarkdownParser
 fun Markdown(
     content: String,
     modifier: Modifier = Modifier.fillMaxSize(),
-    flavour: MarkdownFlavourDescriptor = GFMFlavourDescriptor()
+    flavour: MarkdownFlavourDescriptor = GFMFlavourDescriptor(),
+    textColor: Color = MaterialTheme.colors.onBackground
 ) {
     Column(modifier) {
         val parsedTree = MarkdownParser(flavour).buildMarkdownTreeFromString(content)
 
         CompositionLocalProvider(LocalReferenceLinkHandler provides ReferenceLinkHandlerImpl()) {
             parsedTree.children.forEach { node ->
-                if (!node.handleElement(content, MaterialTheme.colors.onBackground)) {
+                if (!node.handleElement(content, textColor)) {
                     node.children.forEach { child ->
-                        child.handleElement(content, MaterialTheme.colors.onBackground)
+                        child.handleElement(content, textColor)
                     }
                 }
             }


### PR DESCRIPTION
This PR proposes an optional color override for the markdown text. It allows applications that do not use MaterialTheme to still be able to set their text color. The default color is still MaterialTheme.color.onBackground

Also add the ability to specify colors per node-type via an optional map. This is probably a naive approach, I just wanted to get the idea out there.