### PR TITLE
Fix regression, of configurable text and code colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ The library offers the ability to modify different behaviour when rendering the 
 ```kotlin
 Markdown(
     content,
-    colors = MarkdownDefaults.markdownColors(textColor = Color.Red),
-    typography = MarkdownDefaults.markdownTypography(h1 = MaterialTheme.typography.body1)
+    colors = markdownColors(text = Color.Red),
+    typography = markdownTypography(h1 = MaterialTheme.typography.body1)
 )
 ```
 

--- a/app/src/main/java/com/mikepenz/markdown/ui/MainActivity.kt
+++ b/app/src/main/java/com/mikepenz/markdown/ui/MainActivity.kt
@@ -55,6 +55,10 @@ fun MainLayout() {
             [1]: https://mikepenz.dev/
             
             - [Text] Some text
+            
+            ```
+            Code block test
+            ```
         """.trimIndent()
 
         val scrollState = rememberScrollState()

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownCode.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownCode.kt
@@ -20,7 +20,7 @@ private fun MarkdownCode(
     code: String,
     style: TextStyle = LocalMarkdownTypography.current.code
 ) {
-    val backgroundCodeColor = LocalMarkdownColors.current.backgroundCode
+    val backgroundCodeColor = LocalMarkdownColors.current.codeBackground
     Surface(
         color = backgroundCodeColor,
         shape = RoundedCornerShape(8.dp),
@@ -28,6 +28,7 @@ private fun MarkdownCode(
     ) {
         Text(
             code,
+            color = LocalMarkdownColors.current.codeText,
             modifier = Modifier.horizontalScroll(rememberScrollState()).padding(8.dp),
             style = style
         )

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHeader.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHeader.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
+import com.mikepenz.markdown.compose.LocalMarkdownColors
 import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.findChildOfType
@@ -22,7 +23,8 @@ internal fun MarkdownHeader(
         Text(
             it.getTextInNode(content).trim().toString(),
             modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
-            style = style
+            style = style,
+            color = LocalMarkdownColors.current.text
         )
     }
 }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownList.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownList.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.dp
 import com.mikepenz.markdown.compose.LocalBulletListHandler
+import com.mikepenz.markdown.compose.LocalMarkdownColors
 import com.mikepenz.markdown.compose.LocalMarkdownPadding
 import com.mikepenz.markdown.compose.LocalMarkdownTypography
 import com.mikepenz.markdown.compose.LocalOrderedListHandler
@@ -87,7 +88,8 @@ internal fun MarkdownBulletList(
         Row(Modifier.fillMaxWidth()) {
             Text(
                 bulletHandler.transform(child.findChildOfType(MarkdownTokenTypes.LIST_BULLET)?.getTextInNode(content)),
-                style = style
+                style = style,
+                color = LocalMarkdownColors.current.text
             )
             val text = buildAnnotatedString {
                 pushStyle(style.toSpanStyle())

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.*
 import androidx.compose.ui.unit.sp
+import com.mikepenz.markdown.compose.LocalMarkdownColors
 import com.mikepenz.markdown.compose.LocalMarkdownTypography
 import com.mikepenz.markdown.compose.LocalReferenceLinkHandler
 import com.mikepenz.markdown.utils.TAG_IMAGE_URL
@@ -55,6 +56,7 @@ internal fun MarkdownText(
         text = content,
         modifier = textModifier,
         style = style,
+        color = LocalMarkdownColors.current.text,
         inlineContent = mapOf(
             TAG_IMAGE_URL to InlineTextContent(
                 Placeholder(180.sp, 180.sp, PlaceholderVerticalAlign.Bottom) // TODO, identify flexible scaling!

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownColors.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownColors.kt
@@ -11,21 +11,27 @@ interface MarkdownColors {
     /** Represents the color used for the text of this [Markdown] component. */
     val text: Color
 
-    /** Represents the background color for this [Markdown] component. */
-    val backgroundCode: Color
+    /** Represents the color used for the text of code. */
+    val codeText: Color
+    /** Represents the color used for the background of code. */
+    val codeBackground: Color
+
 }
 
 @Immutable
 private class DefaultMarkdownColors(
     override val text: Color,
-    override val backgroundCode: Color
+    override val codeText: Color,
+    override val codeBackground: Color,
 ) : MarkdownColors
 
 @Composable
 fun markdownColor(
     text: Color = MaterialTheme.colors.onBackground,
-    backgroundCode: Color = MaterialTheme.colors.onBackground.copy(alpha = 0.1f)
+    codeText: Color = MaterialTheme.colors.onBackground,
+    codeBackground: Color =MaterialTheme.colors.onBackground.copy(alpha = 0.1f)
 ): MarkdownColors = DefaultMarkdownColors(
     text = text,
-    backgroundCode = backgroundCode
+    codeText = codeText,
+    codeBackground = codeBackground
 )


### PR DESCRIPTION
THe refactor for 0.7.0, didn't actually use the the LocalContentColor where appropriate so text was always black. 

I also updated the README for the new style, added a code block to the sample app, and renamed the `backgroundCode` to `codeBackground` and added `codeText`