### PR TITLE
Protect against `IllegalOutOfBoundsException` for illegal code blocks

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownCode.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownCode.kt
@@ -40,9 +40,13 @@ internal fun MarkdownCodeFence(
     node: ASTNode
 ) {
     // CODE_FENCE_START, FENCE_LANG, {content}, CODE_FENCE_END
-    val start = node.children[2].startOffset
-    val end = node.children[node.children.size - 2].endOffset
-    MarkdownCode(content.subSequence(start, end).toString().replaceIndent())
+    if(node.children.size >= 3) {
+        val start = node.children[2].startOffset
+        val end = node.children[node.children.size - 2].endOffset
+        MarkdownCode(content.subSequence(start, end).toString().replaceIndent())
+    } else {
+        // invalid code block, skipping
+    }
 }
 
 @Composable


### PR DESCRIPTION
- fix `IndexOutOfBounds` for illegal code block
  - FIX https://github.com/mikepenz/multiplatform-markdown-renderer/issues/60