### PR TITLE
Upgrade to compose 1.5.4 | compose-mp 1.5.10 | Kotlin 1.9.20 | Markdown 0.5.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,18 +3,17 @@ buildscript {
         google()
         mavenCentral()
         gradlePluginPortal()
-        maven {
-            setUrl("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-        }
+        maven { setUrl("https://maven.pkg.jetbrains.space/public/p/compose/dev") }
+        maven { setUrl("https://androidx.dev/storage/compose-compiler/repository") }
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.1.1")
+        classpath("com.android.tools.build:gradle:8.1.2")
         classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.21.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0")
-        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.8.20")
-        classpath("com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:10.8.3")
-        classpath("org.jetbrains.compose:compose-gradle-plugin:1.5.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
+        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.9.10")
+        classpath("com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:10.9.2")
+        classpath("org.jetbrains.compose:compose-gradle-plugin:1.5.10")
     }
 }
 
@@ -25,9 +24,8 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven {
-            setUrl("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-        }
+        maven { setUrl("https://maven.pkg.jetbrains.space/public/p/compose/dev") }
+        maven { setUrl("https://androidx.dev/storage/compose-compiler/repository") }
     }
 }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,16 +3,16 @@ object Versions {
     const val androidCompileSdk = 34
     const val androidTargetSdk = androidCompileSdk
 
-    const val kotlin = "1.9.0"
+    const val kotlin = "1.9.20"
 
-    const val markdown = "0.5.0"
+    const val markdown = "0.5.2"
 
-    const val coil = "2.4.0"
-    const val compose = "1.5.0"
-    const val composeCompiler = "1.5.2"
+    const val coil = "2.5.0"
+    const val compose = "1.5.4"
+    const val composeCompiler = "1.5.4-dev-k1.9.20-50f08dfa4b4"
 
-    const val material = "1.9.0"
-    const val activityCompose = "1.7.2"
+    const val material = "1.10.0"
+    const val activityCompose = "1.8.0"
     const val lifecycleKtx = "2.3.1"
 }
 

--- a/multiplatform-markdown-renderer/build.gradle.kts
+++ b/multiplatform-markdown-renderer/build.gradle.kts
@@ -53,6 +53,8 @@ android {
 }
 
 kotlin {
+    targetHierarchy.default()
+
     targets.all {
         compilations.all {
             compilerOptions.configure {
@@ -84,7 +86,6 @@ kotlin {
     macosX64()
     macosArm64()
     iosSimulatorArm64()
-    ios()
 
     sourceSets {
         val commonMain by getting
@@ -102,10 +103,10 @@ kotlin {
         val jsTest by getting {
             dependsOn(fileBasedTest)
         }
-        val nativeMain by creating {
+        val nativeMain by getting {
             dependsOn(commonMain)
         }
-        val nativeTest by creating {
+        val nativeTest by getting {
             dependsOn(fileBasedTest)
         }
         val nativeSourceSets = listOf(


### PR DESCRIPTION
- upgrade to compose 1.5.4
- upgrade to compose-mp 1.5.10
- upgrade to kotlin 1.9.20
- upgrade to coil 2.5.0
- upgrade to markdown 0.5.2