### PR TITLE
Add background for inline code blocks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,18 +3,17 @@ buildscript {
         google()
         mavenCentral()
         gradlePluginPortal()
-        maven {
-            setUrl("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-        }
+        maven { setUrl("https://maven.pkg.jetbrains.space/public/p/compose/dev") }
+        maven { setUrl("https://androidx.dev/storage/compose-compiler/repository") }
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.1.1")
+        classpath("com.android.tools.build:gradle:8.1.2")
         classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.21.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0")
-        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.8.20")
-        classpath("com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:10.8.3")
-        classpath("org.jetbrains.compose:compose-gradle-plugin:1.5.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
+        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.9.10")
+        classpath("com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:10.9.2")
+        classpath("org.jetbrains.compose:compose-gradle-plugin:1.5.10")
     }
 }
 
@@ -25,9 +24,8 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven {
-            setUrl("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-        }
+        maven { setUrl("https://maven.pkg.jetbrains.space/public/p/compose/dev") }
+        maven { setUrl("https://androidx.dev/storage/compose-compiler/repository") }
     }
 }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,16 +3,16 @@ object Versions {
     const val androidCompileSdk = 34
     const val androidTargetSdk = androidCompileSdk
 
-    const val kotlin = "1.9.0"
+    const val kotlin = "1.9.20"
 
-    const val markdown = "0.5.0"
+    const val markdown = "0.5.2"
 
-    const val coil = "2.4.0"
-    const val compose = "1.5.0"
-    const val composeCompiler = "1.5.2"
+    const val coil = "2.5.0"
+    const val compose = "1.5.4"
+    const val composeCompiler = "1.5.4-dev-k1.9.20-50f08dfa4b4"
 
-    const val material = "1.9.0"
-    const val activityCompose = "1.7.2"
+    const val material = "1.10.0"
+    const val activityCompose = "1.8.0"
     const val lifecycleKtx = "2.3.1"
 }
 

--- a/multiplatform-markdown-renderer/build.gradle.kts
+++ b/multiplatform-markdown-renderer/build.gradle.kts
@@ -53,6 +53,8 @@ android {
 }
 
 kotlin {
+    targetHierarchy.default()
+
     targets.all {
         compilations.all {
             compilerOptions.configure {
@@ -84,7 +86,6 @@ kotlin {
     macosX64()
     macosArm64()
     iosSimulatorArm64()
-    ios()
 
     sourceSets {
         val commonMain by getting
@@ -102,10 +103,10 @@ kotlin {
         val jsTest by getting {
             dependsOn(fileBasedTest)
         }
-        val nativeMain by creating {
+        val nativeMain by getting {
             dependsOn(commonMain)
         }
-        val nativeTest by creating {
+        val nativeTest by getting {
             dependsOn(fileBasedTest)
         }
         val nativeSourceSets = listOf(

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownColors.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownColors.kt
@@ -17,6 +17,8 @@ interface MarkdownColors {
     /** Represents the color used for the background of code. */
     val codeBackground: Color
 
+    /** Represents the color used for the inline background of code. */
+    val inlineCodeBackground: Color
 }
 
 @Immutable
@@ -24,15 +26,18 @@ private class DefaultMarkdownColors(
     override val text: Color,
     override val codeText: Color,
     override val codeBackground: Color,
+    override val inlineCodeBackground: Color,
 ) : MarkdownColors
 
 @Composable
 fun markdownColor(
     text: Color = MaterialTheme.colors.onBackground,
     codeText: Color = MaterialTheme.colors.onBackground,
-    codeBackground: Color = MaterialTheme.colors.onBackground.copy(alpha = 0.1f)
+    codeBackground: Color = MaterialTheme.colors.onBackground.copy(alpha = 0.1f),
+    inlineCodeBackground: Color = codeBackground,
 ): MarkdownColors = DefaultMarkdownColors(
     text = text,
     codeText = codeText,
-    codeBackground = codeBackground
+    codeBackground = codeBackground,
+    inlineCodeBackground = inlineCodeBackground,
 )

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
@@ -1,12 +1,14 @@
 package com.mikepenz.markdown.utils
 
 import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import com.mikepenz.markdown.compose.LocalMarkdownColors
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.MarkdownTokenTypes.Companion.TEXT
@@ -15,6 +17,7 @@ import org.intellij.markdown.ast.findChildOfType
 import org.intellij.markdown.ast.getTextInNode
 import org.intellij.markdown.flavours.gfm.GFMTokenTypes
 
+@Composable
 internal fun AnnotatedString.Builder.appendMarkdownLink(content: String, node: ASTNode) {
     val linkText = node.findChildOfType(MarkdownElementTypes.LINK_TEXT)?.children?.innerList()
     if (linkText == null) {
@@ -37,10 +40,12 @@ internal fun AnnotatedString.Builder.appendAutoLink(content: String, node: ASTNo
     pop()
 }
 
+@Composable
 internal fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, node: ASTNode) {
     buildMarkdownAnnotatedString(content, node.children)
 }
 
+@Composable
 internal fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, children: List<ASTNode>) {
     children.forEach { child ->
         when (child.type) {
@@ -62,7 +67,7 @@ internal fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: Strin
             }
 
             MarkdownElementTypes.CODE_SPAN -> {
-                pushStyle(SpanStyle(fontFamily = FontFamily.Monospace))
+                pushStyle(SpanStyle(fontFamily = FontFamily.Monospace, background = LocalMarkdownColors.current.inlineCodeBackground))
                 append(' ')
                 buildMarkdownAnnotatedString(content, child.children.innerList())
                 append(' ')


### PR DESCRIPTION
- set background to inline code (make it new config, so it can be defined as `Unspecified`)
  - FIX #79