### PR TITLE
Added support for processing setext headers

### DIFF
--- a/app/src/main/java/com/mikepenz/markdown/ui/MainActivity.kt
+++ b/app/src/main/java/com/mikepenz/markdown/ui/MainActivity.kt
@@ -56,7 +56,13 @@ fun MainLayout() {
             
             ## Title 2
             
-            ### Title 3
+            ### Title 3 test
+            
+            Title 1
+            ======
+            
+            Title 2
+            ------
             
             [1]: https://mikepenz.dev/
             

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
@@ -32,6 +32,8 @@ import org.intellij.markdown.MarkdownElementTypes.IMAGE
 import org.intellij.markdown.MarkdownElementTypes.LINK_DEFINITION
 import org.intellij.markdown.MarkdownElementTypes.ORDERED_LIST
 import org.intellij.markdown.MarkdownElementTypes.PARAGRAPH
+import org.intellij.markdown.MarkdownElementTypes.SETEXT_1
+import org.intellij.markdown.MarkdownElementTypes.SETEXT_2
 import org.intellij.markdown.MarkdownElementTypes.UNORDERED_LIST
 import org.intellij.markdown.MarkdownTokenTypes.Companion.EOL
 import org.intellij.markdown.MarkdownTokenTypes.Companion.TEXT
@@ -91,6 +93,8 @@ private fun ASTNode.handleElement(components: MarkdownComponents, content: Strin
         ATX_4 -> components.heading4(model)
         ATX_5 -> components.heading5(model)
         ATX_6 -> components.heading6(model)
+        SETEXT_1 -> components.setextHeading1(model)
+        SETEXT_2 -> components.setextHeading2(model)
         BLOCK_QUOTE -> components.blockQuote(model)
         PARAGRAPH -> components.paragraph(model)
         ORDERED_LIST -> components.orderedList(model)

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/components/MarkdownComponents.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/components/MarkdownComponents.kt
@@ -17,6 +17,7 @@ import com.mikepenz.markdown.compose.elements.MarkdownText
 import com.mikepenz.markdown.model.MarkdownTypography
 import org.intellij.markdown.IElementType
 import org.intellij.markdown.MarkdownElementTypes
+import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.findChildOfType
 import org.intellij.markdown.ast.getTextInNode
@@ -48,6 +49,8 @@ fun markdownComponents(
     heading4: MarkdownComponent = CurrentComponentsBridge.heading4,
     heading5: MarkdownComponent = CurrentComponentsBridge.heading5,
     heading6: MarkdownComponent = CurrentComponentsBridge.heading6,
+    setextHeading1: MarkdownComponent = CurrentComponentsBridge.setextHeading1,
+    setextHeading2: MarkdownComponent = CurrentComponentsBridge.setextHeading2,
     blockQuote: MarkdownComponent = CurrentComponentsBridge.blockQuote,
     paragraph: MarkdownComponent = CurrentComponentsBridge.paragraph,
     orderedList: MarkdownComponent = CurrentComponentsBridge.orderedList,
@@ -66,6 +69,8 @@ fun markdownComponents(
     heading4 = heading4,
     heading5 = heading5,
     heading6 = heading6,
+    setextHeading1 = setextHeading1,
+    setextHeading2 = setextHeading2,
     blockQuote = blockQuote,
     paragraph = paragraph,
     orderedList = orderedList,
@@ -90,6 +95,8 @@ interface MarkdownComponents {
     val heading4: MarkdownComponent
     val heading5: MarkdownComponent
     val heading6: MarkdownComponent
+    val setextHeading1: MarkdownComponent
+    val setextHeading2: MarkdownComponent
     val blockQuote: MarkdownComponent
     val paragraph: MarkdownComponent
     val orderedList: MarkdownComponent
@@ -110,6 +117,8 @@ private class DefaultMarkdownComponents(
     override val heading4: MarkdownComponent,
     override val heading5: MarkdownComponent,
     override val heading6: MarkdownComponent,
+    override val setextHeading1: MarkdownComponent,
+    override val setextHeading2: MarkdownComponent,
     override val blockQuote: MarkdownComponent,
     override val paragraph: MarkdownComponent,
     override val orderedList: MarkdownComponent,
@@ -151,6 +160,12 @@ object CurrentComponentsBridge {
     val heading6: MarkdownComponent = {
         MarkdownHeader(it.content, it.node, it.typography.h6)
     }
+    val setextHeading1: MarkdownComponent = {
+        MarkdownHeader(it.content, it.node, it.typography.h1, MarkdownTokenTypes.SETEXT_CONTENT)
+    }
+    val setextHeading2: MarkdownComponent = {
+        MarkdownHeader(it.content, it.node, it.typography.h2, MarkdownTokenTypes.SETEXT_CONTENT)
+    }
     val blockQuote: MarkdownComponent = {
         MarkdownBlockQuote(it.content, it.node)
     }
@@ -171,9 +186,12 @@ object CurrentComponentsBridge {
         MarkdownImage(it.content, it.node)
     }
     val linkDefinition: MarkdownComponent = {
-        val linkLabel = it.node.findChildOfType(MarkdownElementTypes.LINK_LABEL)?.getTextInNode(it.content)?.toString()
+        val linkLabel =
+            it.node.findChildOfType(MarkdownElementTypes.LINK_LABEL)?.getTextInNode(it.content)
+                ?.toString()
         if (linkLabel != null) {
-            val destination = it.node.findChildOfType(MarkdownElementTypes.LINK_DESTINATION)?.getTextInNode(it.content)?.toString()
+            val destination = it.node.findChildOfType(MarkdownElementTypes.LINK_DESTINATION)
+                ?.getTextInNode(it.content)?.toString()
             LocalReferenceLinkHandler.current.store(linkLabel, destination)
         }
     }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHeader.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHeader.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import com.mikepenz.markdown.utils.buildMarkdownAnnotatedString
+import org.intellij.markdown.IElementType
 import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.findChildOfType
@@ -12,10 +13,11 @@ import org.intellij.markdown.ast.findChildOfType
 internal fun MarkdownHeader(
     content: String,
     node: ASTNode,
-    style: TextStyle
+    style: TextStyle,
+    contentChildType: IElementType = MarkdownTokenTypes.ATX_CONTENT,
 ) {
 
-    node.findChildOfType(MarkdownTokenTypes.ATX_CONTENT)?.let {
+    node.findChildOfType(contentChildType)?.let {
         val styledText = buildAnnotatedString {
             pushStyle(style.toSpanStyle())
             buildMarkdownAnnotatedString(content, it)

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
@@ -96,7 +96,9 @@ internal fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: Strin
             MarkdownTokenTypes.BACKTICK -> append('`')
             MarkdownTokenTypes.HARD_LINE_BREAK -> append("\n\n")
             MarkdownTokenTypes.EOL -> append('\n')
-            MarkdownTokenTypes.WHITE_SPACE -> append(' ')
+            MarkdownTokenTypes.WHITE_SPACE -> if (length > 0) {
+                append(' ')
+            }
         }
     }
 }


### PR DESCRIPTION
Added support for setext headers

```markdown
Title 1
======

Title 2
------
```

Also fixes a bug where whitespace is placed at the start of elements like ATX headers.