### PR TITLE
Handle labeled links correctly when they are in the same markdown text block

### DIFF
--- a/app/src/main/java/com/mikepenz/markdown/ui/MainActivity.kt
+++ b/app/src/main/java/com/mikepenz/markdown/ui/MainActivity.kt
@@ -51,6 +51,8 @@ fun MainLayout() {
             
             Links with links as label are also handled:
             [https://mikepenz.dev](https://mikepenz.dev)
+            [https://github.com/mikepenz](https://github.com/mikepenz)
+            [https://blog.mikepenz.dev/](https://blog.mikepenz.dev/)
             
             Some `inline` code is also supported!
             

--- a/app/src/main/java/com/mikepenz/markdown/ui/MainActivity.kt
+++ b/app/src/main/java/com/mikepenz/markdown/ui/MainActivity.kt
@@ -48,11 +48,12 @@ fun MainLayout() {
             [Reference Link Test][1] 
             
             But can also be a auto link: https://mikepenz.dev
+   
             
             Links with links as label are also handled:
             [https://mikepenz.dev](https://mikepenz.dev)
             [https://github.com/mikepenz](https://github.com/mikepenz)
-            [https://blog.mikepenz.dev/](https://blog.mikepenz.dev/)
+            [Mike Penz's Blog](https://blog.mikepenz.dev/)
             
             Some `inline` code is also supported!
             

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
@@ -53,9 +53,9 @@ internal fun MarkdownText(
         detectTapGestures { pos ->
             layoutResult.value?.let { layoutResult ->
                 val position = layoutResult.getOffsetForPosition(pos)
-                content.getStringAnnotations(TAG_URL, position, position)
-                    .firstOrNull()
-                    ?.let { uriHandler.openUri(referenceLinkHandler.find(it.item)) }
+                content.getStringAnnotations(TAG_URL, position, position).reversed().firstOrNull()?.let{
+                    uriHandler.openUri(referenceLinkHandler.find(it.item))
+                }
             }
         }
     } else modifier


### PR DESCRIPTION
When labelled links are in the same MarkdownText the current version only ever opens the first link.
```
[https://mikepenz.dev](https://mikepenz.dev)
[https://github.com/mikepenz](https://github.com/mikepenz)
[Mike Penz's Blog](https://blog.mikepenz.dev/)
 ```
results in `https://mikepenz.dev` always being the one opened no matter what.
If the markdown is formatted as individual MarkdownText's this works correctly
```
[https://mikepenz.dev](https://mikepenz.dev)

[https://github.com/mikepenz](https://github.com/mikepenz)

[Mike Penz's Blog](https://blog.mikepenz.dev/)
```

I believe the issue is the code block always takes the first, and in the first scenario when you click the 2nd link, the 1st link is present in the markdown already so it takes that one.  
because `content.getStringAnnotations(TAG_URL, position, position)` has a size of 2 not 1. 

This is resolved by reversing the list so it always takes the last found link as that is the one being clicked.