### PR TITLE
Update Dependencies | Kotlin 1.9.21 | markdown 0.6.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ buildscript {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.9.10")
         classpath("com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:10.9.2")
-        classpath("org.jetbrains.compose:compose-gradle-plugin:1.5.10")
+        classpath("org.jetbrains.compose:compose-gradle-plugin:1.5.11")
     }
 }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,16 +3,16 @@ object Versions {
     const val androidCompileSdk = 34
     const val androidTargetSdk = androidCompileSdk
 
-    const val kotlin = "1.9.20"
+    const val kotlin = "1.9.21"
 
-    const val markdown = "0.5.2"
+    const val markdown = "0.6.0"
 
     const val coil = "2.5.0"
     const val compose = "1.5.4"
-    const val composeCompiler = "1.5.4-dev-k1.9.20-50f08dfa4b4"
+    const val composeCompiler = "1.5.5"
 
     const val material = "1.10.0"
-    const val activityCompose = "1.8.0"
+    const val activityCompose = "1.8.1"
     const val lifecycleKtx = "2.3.1"
 }
 


### PR DESCRIPTION
- update kotlin to 1.9.21
- update to markdown 0.6.0
- update composeCompiler to 1.5.5
- update to activityCompose 1.8.1