### PR TITLE
Improve `BulletHandler` | Support unconventional ordered lists

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/ComposeLocal.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/ComposeLocal.kt
@@ -2,25 +2,20 @@ package com.mikepenz.markdown.compose
 
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
-import com.mikepenz.markdown.model.BulletHandler
-import com.mikepenz.markdown.model.ImageTransformer
-import com.mikepenz.markdown.model.MarkdownColors
-import com.mikepenz.markdown.model.MarkdownPadding
-import com.mikepenz.markdown.model.MarkdownTypography
-import com.mikepenz.markdown.model.ReferenceLinkHandler
+import com.mikepenz.markdown.model.*
 
 /**
  * The CompositionLocal to provide functionality related to transforming the bullet of an ordered list
  */
 val LocalBulletListHandler = staticCompositionLocalOf {
-    return@staticCompositionLocalOf BulletHandler { "• " }
+    return@staticCompositionLocalOf BulletHandler { _, _, _ -> "• " }
 }
 
 /**
  * The CompositionLocal to provide functionality related to transforming the bullet of an ordered list
  */
 val LocalOrderedListHandler = staticCompositionLocalOf {
-    return@staticCompositionLocalOf BulletHandler { "$it " }
+    return@staticCompositionLocalOf BulletHandler { _, _, index -> "${index + 1}. " }
 }
 
 /**

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownList.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownList.kt
@@ -10,17 +10,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.dp
-import com.mikepenz.markdown.compose.LocalBulletListHandler
-import com.mikepenz.markdown.compose.LocalMarkdownColors
-import com.mikepenz.markdown.compose.LocalMarkdownPadding
-import com.mikepenz.markdown.compose.LocalMarkdownTypography
-import com.mikepenz.markdown.compose.LocalOrderedListHandler
+import com.mikepenz.markdown.compose.*
 import com.mikepenz.markdown.utils.buildMarkdownAnnotatedString
 import com.mikepenz.markdown.utils.filterNonListTypes
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownElementTypes.ORDERED_LIST
 import org.intellij.markdown.MarkdownElementTypes.UNORDERED_LIST
-import org.intellij.markdown.MarkdownTokenTypes
+import org.intellij.markdown.MarkdownTokenTypes.Companion.LIST_BULLET
+import org.intellij.markdown.MarkdownTokenTypes.Companion.LIST_NUMBER
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.findChildOfType
 import org.intellij.markdown.ast.getTextInNode
@@ -31,23 +28,32 @@ private fun MarkdownListItems(
     node: ASTNode,
     style: TextStyle = LocalMarkdownTypography.current.list,
     level: Int = 0,
-    item: @Composable (child: ASTNode) -> Unit
+    item: @Composable (index: Int, child: ASTNode) -> Unit
 ) {
     val listDp = LocalMarkdownPadding.current.list
     val indentListDp = LocalMarkdownPadding.current.indentList
     Column(modifier = Modifier.padding(start = (indentListDp) * level, top = listDp, bottom = listDp)) {
+        var index = 0
         node.children.forEach { child ->
             when (child.type) {
                 MarkdownElementTypes.LIST_ITEM -> {
-                    item(child)
+                    item(index, child)
                     when (child.children.last().type) {
                         ORDERED_LIST -> MarkdownOrderedList(content, child, style, level + 1)
                         UNORDERED_LIST -> MarkdownBulletList(content, child, style, level + 1)
                     }
+                    index++
                 }
 
-                ORDERED_LIST -> MarkdownOrderedList(content, child, style, level + 1)
-                UNORDERED_LIST -> MarkdownBulletList(content, child, style, level + 1)
+                ORDERED_LIST -> {
+                    MarkdownOrderedList(content, child, style, level + 1)
+                    index++
+                }
+
+                UNORDERED_LIST -> {
+                    MarkdownBulletList(content, child, style, level + 1)
+                    index++
+                }
             }
         }
     }
@@ -61,10 +67,10 @@ internal fun MarkdownOrderedList(
     level: Int = 0
 ) {
     val orderedListHandler = LocalOrderedListHandler.current
-    MarkdownListItems(content, node, style, level) { child ->
+    MarkdownListItems(content, node, style, level) { index, child ->
         Row(Modifier.fillMaxWidth()) {
             Text(
-                text = orderedListHandler.transform(child.findChildOfType(MarkdownTokenTypes.LIST_NUMBER)?.getTextInNode(content)),
+                text = orderedListHandler.transform(LIST_NUMBER, child.findChildOfType(LIST_NUMBER)?.getTextInNode(content), index),
                 style = style,
                 color = LocalMarkdownColors.current.text
             )
@@ -86,10 +92,10 @@ internal fun MarkdownBulletList(
     level: Int = 0
 ) {
     val bulletHandler = LocalBulletListHandler.current
-    MarkdownListItems(content, node, style, level) { child ->
+    MarkdownListItems(content, node, style, level) { index, child ->
         Row(Modifier.fillMaxWidth()) {
             Text(
-                bulletHandler.transform(child.findChildOfType(MarkdownTokenTypes.LIST_BULLET)?.getTextInNode(content)),
+                bulletHandler.transform(LIST_BULLET, child.findChildOfType(LIST_BULLET)?.getTextInNode(content), index),
                 style = style,
                 color = LocalMarkdownColors.current.text
             )

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/BulletHandler.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/BulletHandler.kt
@@ -1,6 +1,8 @@
 package com.mikepenz.markdown.model
 
+import org.intellij.markdown.IElementType
+
 /** An interface of providing use case specific un/ordered list handling.*/
 fun interface BulletHandler {
-    fun transform(bullet: CharSequence?): String
+    fun transform(type: IElementType, bullet: CharSequence?, index: Int): String
 }


### PR DESCRIPTION
- expand `BulletHandler` to expose more information (index + type)
- adjust ordered list handling to always count up with a number
  - Handle ordered lists (which are defined 1., 1., ...)
  - FIX https://github.com/mikepenz/multiplatform-markdown-renderer/issues/89