### PR TITLE
Default components public | Forward `modifier` in `MarkdownParagraph` | Forward `ColumnScope` to `MarkdownComponents`

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,48 @@ CompositionLocalProvider(LocalOrderedListHandler provides { "A.) " }) {
 }
 ```
 
+### Custom Components
+
+Since v0.9.0 it is possible to provide custom components, instead of the default ones. 
+This can be done by providing the components `MarkdownComponents` to the `Markdown` composable. 
+
+Use the `markdownComponents()` to keep defaults for non overwritten components.
+
+The `MarkdownComponent` will expose access to the `content: String`, `node: ASTNode`, `typography: MarkdownTypography`, offering full flexibility.
+
+```kotlin
+// Simple adjusted paragraph with different Modifier.
+val customParagraphComponent: MarkdownComponent = {
+    MarkdownParagraph(it.content, it.node, Modifier.align(Alignment.End))
+}
+
+// Full custom paragraph example
+val customParagraphComponent: MarkdownComponent = {
+    // build a styled paragraph. (util function provided by the library)
+    val styledText = buildAnnotatedString {
+        pushStyle(LocalMarkdownTypography.current.paragraph.toSpanStyle())
+        buildMarkdownAnnotatedString(content, it.node)
+        pop()
+    }
+
+    // define the `Text` composable
+    Text(
+        styledText,
+        modifier = Modifier.align(Alignment.End),
+        textAlign = TextAlign.End
+    )
+}
+
+// Define the `Markdown` composeable and pass in the custom paragraph component
+Markdown(
+    content,
+    components = markdownComponents(
+        paragraph = customParagraphComponent
+    )
+)
+
+```
+
 </p>
 </details>
 
@@ -148,7 +190,7 @@ Copyright for portions of the code are held by [Erik Hellman, 2020] as part of p
 
 ## License
 
-    Copyright 2023 Mike Penz
+    Copyright 2024 Mike Penz
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
@@ -1,24 +1,13 @@
 package com.mikepenz.markdown.compose
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import com.mikepenz.markdown.compose.components.MarkdownComponentModel
 import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.markdownComponents
-import com.mikepenz.markdown.model.ImageTransformer
-import com.mikepenz.markdown.model.ImageTransformerImpl
-import com.mikepenz.markdown.model.MarkdownColors
-import com.mikepenz.markdown.model.MarkdownPadding
-import com.mikepenz.markdown.model.MarkdownTypography
-import com.mikepenz.markdown.model.ReferenceLinkHandlerImpl
-import com.mikepenz.markdown.model.markdownColor
-import com.mikepenz.markdown.model.markdownPadding
-import com.mikepenz.markdown.model.markdownTypography
+import com.mikepenz.markdown.model.*
 import org.intellij.markdown.MarkdownElementTypes.ATX_1
 import org.intellij.markdown.MarkdownElementTypes.ATX_2
 import org.intellij.markdown.MarkdownElementTypes.ATX_3
@@ -63,9 +52,9 @@ fun Markdown(
         Column(modifier) {
             val parsedTree = MarkdownParser(flavour).buildMarkdownTreeFromString(content)
             parsedTree.children.forEach { node ->
-                if (!node.handleElement(components, content)) {
+                if (!handleElement(node, components, content)) {
                     node.children.forEach { child ->
-                        child.handleElement(components, content)
+                        handleElement(child, components, content)
                     }
                 }
             }
@@ -74,35 +63,35 @@ fun Markdown(
 }
 
 @Composable
-private fun ASTNode.handleElement(components: MarkdownComponents, content: String): Boolean {
+private fun ColumnScope.handleElement(node: ASTNode, components: MarkdownComponents, content: String): Boolean {
     val model = MarkdownComponentModel(
         content = content,
-        node = this,
+        node = node,
         typography = LocalMarkdownTypography.current
     )
     var handled = true
     Spacer(Modifier.height(LocalMarkdownPadding.current.block))
-    when (type) {
-        TEXT -> components.text(model)
-        EOL -> components.eol(model)
-        CODE_FENCE -> components.codeFence(model)
-        CODE_BLOCK -> components.codeBlock(model)
-        ATX_1 -> components.heading1(model)
-        ATX_2 -> components.heading2(model)
-        ATX_3 -> components.heading3(model)
-        ATX_4 -> components.heading4(model)
-        ATX_5 -> components.heading5(model)
-        ATX_6 -> components.heading6(model)
-        SETEXT_1 -> components.setextHeading1(model)
-        SETEXT_2 -> components.setextHeading2(model)
-        BLOCK_QUOTE -> components.blockQuote(model)
-        PARAGRAPH -> components.paragraph(model)
-        ORDERED_LIST -> components.orderedList(model)
-        UNORDERED_LIST -> components.unorderedList(model)
-        IMAGE -> components.image(model)
-        LINK_DEFINITION -> components.linkDefinition(model)
+    when (node.type) {
+        TEXT -> components.text(this@handleElement, model)
+        EOL -> components.eol(this@handleElement, model)
+        CODE_FENCE -> components.codeFence(this@handleElement, model)
+        CODE_BLOCK -> components.codeBlock(this@handleElement, model)
+        ATX_1 -> components.heading1(this@handleElement, model)
+        ATX_2 -> components.heading2(this@handleElement, model)
+        ATX_3 -> components.heading3(this@handleElement, model)
+        ATX_4 -> components.heading4(this@handleElement, model)
+        ATX_5 -> components.heading5(this@handleElement, model)
+        ATX_6 -> components.heading6(this@handleElement, model)
+        SETEXT_1 -> components.setextHeading1(this@handleElement, model)
+        SETEXT_2 -> components.setextHeading2(this@handleElement, model)
+        BLOCK_QUOTE -> components.blockQuote(this@handleElement, model)
+        PARAGRAPH -> components.paragraph(this@handleElement, model)
+        ORDERED_LIST -> components.orderedList(this@handleElement, model)
+        UNORDERED_LIST -> components.unorderedList(this@handleElement, model)
+        IMAGE -> components.image(this@handleElement, model)
+        LINK_DEFINITION -> components.linkDefinition(this@handleElement, model)
         else -> {
-            handled = components.custom?.invoke(type, model) != null
+            handled = components.custom?.invoke(this@handleElement, node.type, model) != null
         }
     }
 

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/components/MarkdownComponents.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/components/MarkdownComponents.kt
@@ -170,7 +170,7 @@ object CurrentComponentsBridge {
         MarkdownBlockQuote(it.content, it.node)
     }
     val paragraph: MarkdownComponent = {
-        MarkdownParagraph(it.content, it.node, it.typography.paragraph)
+        MarkdownParagraph(it.content, it.node, style = it.typography.paragraph)
     }
     val orderedList: MarkdownComponent = {
         Column(modifier = Modifier) {

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/components/MarkdownComponents.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/components/MarkdownComponents.kt
@@ -1,19 +1,12 @@
 package com.mikepenz.markdown.compose.components
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
 import com.mikepenz.markdown.compose.LocalReferenceLinkHandler
-import com.mikepenz.markdown.compose.elements.MarkdownBlockQuote
-import com.mikepenz.markdown.compose.elements.MarkdownBulletList
-import com.mikepenz.markdown.compose.elements.MarkdownCodeBlock
-import com.mikepenz.markdown.compose.elements.MarkdownCodeFence
-import com.mikepenz.markdown.compose.elements.MarkdownHeader
-import com.mikepenz.markdown.compose.elements.MarkdownImage
-import com.mikepenz.markdown.compose.elements.MarkdownOrderedList
-import com.mikepenz.markdown.compose.elements.MarkdownParagraph
-import com.mikepenz.markdown.compose.elements.MarkdownText
+import com.mikepenz.markdown.compose.elements.*
 import com.mikepenz.markdown.model.MarkdownTypography
 import org.intellij.markdown.IElementType
 import org.intellij.markdown.MarkdownElementTypes
@@ -22,9 +15,9 @@ import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.findChildOfType
 import org.intellij.markdown.ast.getTextInNode
 
-typealias MarkdownComponent = @Composable (MarkdownComponentModel) -> Unit
+typealias MarkdownComponent = @Composable ColumnScope.(MarkdownComponentModel) -> Unit
 
-typealias CustomMarkdownComponent = @Composable (IElementType, MarkdownComponentModel) -> Unit
+typealias CustomMarkdownComponent = @Composable ColumnScope.(IElementType, MarkdownComponentModel) -> Unit
 
 /**
  * Model holding data relevant for a component

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownBlockQuote.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownBlockQuote.kt
@@ -15,7 +15,7 @@ import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.getTextInNode
 
 @Composable
-internal fun MarkdownBlockQuote(
+fun MarkdownBlockQuote(
     content: String,
     node: ASTNode,
     style: TextStyle = LocalMarkdownTypography.current.quote

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownCode.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownCode.kt
@@ -36,7 +36,7 @@ private fun MarkdownCode(
 }
 
 @Composable
-internal fun MarkdownCodeFence(
+fun MarkdownCodeFence(
     content: String,
     node: ASTNode
 ) {
@@ -51,7 +51,7 @@ internal fun MarkdownCodeFence(
 }
 
 @Composable
-internal fun MarkdownCodeBlock(
+fun MarkdownCodeBlock(
     content: String,
     node: ASTNode
 ) {

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHeader.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHeader.kt
@@ -10,7 +10,7 @@ import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.findChildOfType
 
 @Composable
-internal fun MarkdownHeader(
+fun MarkdownHeader(
     content: String,
     node: ASTNode,
     style: TextStyle,

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownImage.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownImage.kt
@@ -9,7 +9,7 @@ import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.getTextInNode
 
 @Composable
-internal fun MarkdownImage(content: String, node: ASTNode) {
+fun MarkdownImage(content: String, node: ASTNode) {
 
     val link = node.findChildOfTypeRecursive(MarkdownElementTypes.LINK_DESTINATION)?.getTextInNode(content)?.toString() ?: return
 

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownList.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownList.kt
@@ -23,7 +23,7 @@ import org.intellij.markdown.ast.findChildOfType
 import org.intellij.markdown.ast.getTextInNode
 
 @Composable
-private fun MarkdownListItems(
+fun MarkdownListItems(
     content: String,
     node: ASTNode,
     style: TextStyle = LocalMarkdownTypography.current.list,
@@ -60,7 +60,7 @@ private fun MarkdownListItems(
 }
 
 @Composable
-internal fun MarkdownOrderedList(
+fun MarkdownOrderedList(
     content: String,
     node: ASTNode,
     style: TextStyle = LocalMarkdownTypography.current.ordered,
@@ -85,7 +85,7 @@ internal fun MarkdownOrderedList(
 }
 
 @Composable
-internal fun MarkdownBulletList(
+fun MarkdownBulletList(
     content: String,
     node: ASTNode,
     style: TextStyle = LocalMarkdownTypography.current.bullet,

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownParagraph.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownParagraph.kt
@@ -1,6 +1,7 @@
 package com.mikepenz.markdown.compose.elements
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import com.mikepenz.markdown.compose.LocalMarkdownTypography
@@ -8,9 +9,10 @@ import com.mikepenz.markdown.utils.buildMarkdownAnnotatedString
 import org.intellij.markdown.ast.ASTNode
 
 @Composable
-internal fun MarkdownParagraph(
+fun MarkdownParagraph(
     content: String,
     node: ASTNode,
+    modifier: Modifier = Modifier,
     style: TextStyle = LocalMarkdownTypography.current.paragraph
 ) {
     val styledText = buildAnnotatedString {
@@ -18,5 +20,5 @@ internal fun MarkdownParagraph(
         buildMarkdownAnnotatedString(content, node)
         pop()
     }
-    MarkdownText(styledText, style = style)
+    MarkdownText(styledText, modifier = modifier, style = style)
 }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
@@ -13,11 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.Placeholder
-import androidx.compose.ui.text.PlaceholderVerticalAlign
-import androidx.compose.ui.text.TextLayoutResult
-import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.*
 import androidx.compose.ui.unit.sp
 import com.mikepenz.markdown.compose.LocalImageTransformer
 import com.mikepenz.markdown.compose.LocalMarkdownColors
@@ -29,7 +25,7 @@ import com.mikepenz.markdown.utils.TAG_URL
 
 
 @Composable
-internal fun MarkdownText(
+fun MarkdownText(
     content: String,
     modifier: Modifier = Modifier,
     style: TextStyle = LocalMarkdownTypography.current.text
@@ -38,7 +34,7 @@ internal fun MarkdownText(
 }
 
 @Composable
-internal fun MarkdownText(
+fun MarkdownText(
     content: AnnotatedString,
     modifier: Modifier = Modifier,
     style: TextStyle = LocalMarkdownTypography.current.text

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
@@ -40,13 +40,31 @@ internal fun AnnotatedString.Builder.appendAutoLink(content: String, node: ASTNo
     pop()
 }
 
+/**
+ * Builds an [AnnotatedString] with the contents of the given Markdown [ASTNode] node.
+ *
+ * This method automatically constructs the string with child components like:
+ * - Paragraph
+ * - Image
+ * - Strong
+ * - ...
+ */
 @Composable
-internal fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, node: ASTNode) {
+fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, node: ASTNode) {
     buildMarkdownAnnotatedString(content, node.children)
 }
 
+/**
+ * Builds an [AnnotatedString] with the contents of the given Markdown [ASTNode] node.
+ *
+ * This method automatically constructs the string with child components like:
+ * - Paragraph
+ * - Image
+ * - Strong
+ * - ...
+ */
 @Composable
-internal fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, children: List<ASTNode>) {
+fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, children: List<ASTNode>) {
     children.forEach { child ->
         when (child.type) {
             MarkdownElementTypes.PARAGRAPH -> buildMarkdownAnnotatedString(content, child)


### PR DESCRIPTION
- expose default Markdown components for easier use for custom components
- add Modifier to MarkdownParagraph forwarded to MarkdownText
- forward ColumnScope to MarkdownComponents to allow applying related Modifiers (like align)