### PR TITLE
Add SVG support for images

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -36,5 +36,6 @@ object Deps {
         const val material = "androidx.compose.material:material:${Versions.compose}"
 
         const val coilCompose = "io.coil-kt:coil-compose:${Versions.coil}"
+        const val coilComposeSvg = "io.coil-kt:coil-svg:${Versions.coil}"
     }
 }

--- a/multiplatform-markdown-renderer/build.gradle.kts
+++ b/multiplatform-markdown-renderer/build.gradle.kts
@@ -146,6 +146,7 @@ dependencies {
         exclude("androidx.compose.foundation")
         exclude("androidx.compose.ui")
     }
+    androidMainImplementation(Deps.Compose.coilComposeSvg)
 }
 
 tasks.dokkaHtml.configure {

--- a/multiplatform-markdown-renderer/src/androidMain/kotlin/com/mikepenz/markdown/utils/ImagePainterProvider.kt
+++ b/multiplatform-markdown-renderer/src/androidMain/kotlin/com/mikepenz/markdown/utils/ImagePainterProvider.kt
@@ -12,11 +12,15 @@ import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import coil.size.Size
+import coil3.svg.SvgDecoder
 
 @Composable
 internal actual fun imagePainter(url: String): Painter? {
     return rememberAsyncImagePainter(
         model = ImageRequest.Builder(LocalContext.current)
+            .components {
+                add(SvgDecoder.Factory())
+            }
             .data(url)
             .size(Size.ORIGINAL)
             .build()


### PR DESCRIPTION
This should partially address #121

By default, coil does not support SVG images, instead trying to render them normally and failing.

Note that this isn't thoroughly tested but should work according to https://coil-kt.github.io/coil/svgs/