### PR TITLE
Update to `jetbrains/markdown@0.7.0` | Add `wasmJs` target

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -5,7 +5,7 @@ object Versions {
 
     const val kotlin = "1.9.23"
 
-    const val markdown = "0.6.1"
+    const val markdown = "0.7.0"
 
     const val coil = "2.6.0"
     const val compose = "1.6.4"

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,6 +29,7 @@ kotlin.js.compiler=both
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 
+org.jetbrains.compose.experimental.wasm.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true

--- a/multiplatform-markdown-renderer-m2/build.gradle.kts
+++ b/multiplatform-markdown-renderer-m2/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
     kotlin("multiplatform")
@@ -58,6 +59,10 @@ kotlin {
                 kotlinOptions.jvmTarget = "11"
             }
         }
+    }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
     }
     js(IR) {
         nodejs()

--- a/multiplatform-markdown-renderer-m3/build.gradle.kts
+++ b/multiplatform-markdown-renderer-m3/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
     kotlin("multiplatform")
@@ -61,6 +62,10 @@ kotlin {
     }
     js(IR) {
         nodejs()
+    }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
     }
     macosX64()
     macosArm64()

--- a/multiplatform-markdown-renderer/build.gradle.kts
+++ b/multiplatform-markdown-renderer/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
     kotlin("multiplatform")
@@ -67,7 +68,6 @@ kotlin {
             }
         }
     }
-
     androidTarget {
         publishLibraryVariants("release")
     }
@@ -83,6 +83,10 @@ kotlin {
                 excludeCategories("org.intellij.markdown.ParserPerformanceTest")
             }
         }
+    }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
     }
     js(IR) {
         nodejs()

--- a/multiplatform-markdown-renderer/src/wasmJsMain/kotlin/com/mikepenz/markdown/utils/ImagePainterProvider.multiplatform-markdown-renderer.js.kt
+++ b/multiplatform-markdown-renderer/src/wasmJsMain/kotlin/com/mikepenz/markdown/utils/ImagePainterProvider.multiplatform-markdown-renderer.js.kt
@@ -1,0 +1,15 @@
+package com.mikepenz.markdown.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.painter.Painter
+
+@Composable
+internal actual fun imagePainter(url: String): Painter? {
+    return null
+}
+
+@Composable
+internal actual fun painterIntrinsicSize(painter: Painter): Size {
+    return painter.intrinsicSize
+}


### PR DESCRIPTION
- update to markdown library 0.7.0
- add the new wasm target
    - FIX https://github.com/mikepenz/multiplatform-markdown-renderer/issues/55