### PR TITLE
enhancement: link clickable span detection

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/components/MarkdownComponents.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/components/MarkdownComponents.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Modifier
 import com.mikepenz.markdown.compose.LocalReferenceLinkHandler
 import com.mikepenz.markdown.compose.elements.*
 import com.mikepenz.markdown.model.MarkdownTypography
+import com.mikepenz.markdown.utils.getLinkAnchorText
 import org.intellij.markdown.IElementType
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
@@ -184,13 +185,16 @@ object CurrentComponentsBridge {
         MarkdownImage(it.content, it.node)
     }
     val linkDefinition: MarkdownComponent = {
-        val linkLabel =
-            it.node.findChildOfType(MarkdownElementTypes.LINK_LABEL)?.getTextInNode(it.content)
-                ?.toString()
-        if (linkLabel != null) {
+        val anchorText = it.node.getLinkAnchorText(it.content)
+        val linkLabel = it.node.findChildOfType(MarkdownElementTypes.LINK_LABEL)
+            ?.getTextInNode(it.content)
+            ?.toString()
+        (anchorText ?: linkLabel)?.also { label ->
             val destination = it.node.findChildOfType(MarkdownElementTypes.LINK_DESTINATION)
                 ?.getTextInNode(it.content)?.toString()
-            LocalReferenceLinkHandler.current.store(linkLabel, destination)
+            if (destination != null) {
+                LocalReferenceLinkHandler.current.store(label, destination)
+            }
         }
     }
     val horizontalRule: MarkdownComponent = {

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
@@ -4,6 +4,8 @@ import org.intellij.markdown.IElementType
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.ast.findChildOfType
+import org.intellij.markdown.ast.getTextInNode
 
 /**
  * Tag used to indicate an url for inline content. Required for click handling.
@@ -44,3 +46,14 @@ internal fun List<ASTNode>.innerList(): List<ASTNode> = this.subList(1, this.siz
 internal fun List<ASTNode>.filterNonListTypes(): List<ASTNode> = this.filter { n ->
     n.type != MarkdownElementTypes.ORDERED_LIST && n.type != MarkdownElementTypes.UNORDERED_LIST && n.type != MarkdownTokenTypes.EOL
 }
+
+/**
+ * Helper function to extract the link anchor text (i.e. the clickable label) of a hyperlink node inside
+ * a given content of text. Returns null if it is not possible to find any.
+ */
+internal fun ASTNode.getLinkAnchorText(content: String): String? = buildString {
+    findChildOfType(MarkdownElementTypes.LINK_TEXT)?.children?.innerList().orEmpty()
+        .forEach { node ->
+            append(node.getTextInNode(content))
+        }
+}.takeIf { text -> text.isNotEmpty() }


### PR DESCRIPTION
Hi! I am using your library in my Lemmy client and I really like it (lightweight, easy to use, extensible, multiplatform to the core, perfect MD integration, etc.). Kudos!

My users reported the following bug: if there is a link inside a text node, the whole line is clickable and opens it even if the tapped position exceeds the anchor text length, i. e. provided that the tap event occurs in the same line after the link, the link is opened anyways.

Steps to reproduce: in the example application change the last two lines of the sample text like this
```
  [https://github.com/mikepenz](https://github.com/mikepenz), but this part of the line is not clickable
  [Mike Penz's Blog](https://blog.mikepenz.dev/) neither this part of the line should be clickable
```

The solution was a little more difficult than expected, because the LINK_DEFINITION node handler is not called for autolinks or links inside a text node, but just for internal Markdown references, so I had to modify even the text handlers. Another "weird" behaviour which I found is that annotations are added multiple times for the same reference, which was somehow "hidden" by the `reversed().firstOrNull()` access to the list, but the test on the hit rect against the annotation position had to be improved.