### PR TITLE
Offer new color option for `inlineCodeText`

### DIFF
--- a/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/MarkdownColors.kt
+++ b/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/MarkdownColors.kt
@@ -10,6 +10,7 @@ import com.mikepenz.markdown.model.MarkdownColors
 fun markdownColor(
     text: Color = MaterialTheme.colors.onBackground,
     codeText: Color = MaterialTheme.colors.onBackground,
+    inlineCodeText: Color = codeText,
     linkText: Color = text,
     codeBackground: Color = MaterialTheme.colors.onBackground.copy(alpha = 0.1f),
     inlineCodeBackground: Color = codeBackground,
@@ -17,6 +18,7 @@ fun markdownColor(
 ): MarkdownColors = DefaultMarkdownColors(
     text = text,
     codeText = codeText,
+    inlineCodeText = inlineCodeText,
     linkText = linkText,
     codeBackground = codeBackground,
     inlineCodeBackground = inlineCodeBackground,

--- a/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/MarkdownColors.kt
+++ b/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/MarkdownColors.kt
@@ -10,6 +10,7 @@ import com.mikepenz.markdown.model.MarkdownColors
 fun markdownColor(
     text: Color = MaterialTheme.colorScheme.onBackground,
     codeText: Color = MaterialTheme.colorScheme.onBackground,
+    inlineCodeText: Color = codeText,
     linkText: Color = text,
     codeBackground: Color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.1f),
     inlineCodeBackground: Color = codeBackground,
@@ -17,6 +18,7 @@ fun markdownColor(
 ): MarkdownColors = DefaultMarkdownColors(
     text = text,
     codeText = codeText,
+    inlineCodeText = inlineCodeText,
     linkText = linkText,
     codeBackground = codeBackground,
     inlineCodeBackground = inlineCodeBackground,

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownColors.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownColors.kt
@@ -12,6 +12,9 @@ interface MarkdownColors {
     /** Represents the color used for the text of code. */
     val codeText: Color
 
+    /** Represents the color used for the text of code. */
+    val inlineCodeText: Color
+
     /** Represents the color used for the text of links. */
     val linkText: Color
 
@@ -29,6 +32,7 @@ interface MarkdownColors {
 class DefaultMarkdownColors(
     override val text: Color,
     override val codeText: Color,
+    override val inlineCodeText: Color,
     override val linkText: Color,
     override val codeBackground: Color,
     override val inlineCodeBackground: Color,

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
@@ -85,7 +85,7 @@ fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, childr
             }
 
             MarkdownElementTypes.CODE_SPAN -> {
-                pushStyle(SpanStyle(fontFamily = FontFamily.Monospace, background = LocalMarkdownColors.current.inlineCodeBackground))
+                pushStyle(SpanStyle(fontFamily = FontFamily.Monospace, color = LocalMarkdownColors.current.inlineCodeText, background = LocalMarkdownColors.current.inlineCodeBackground))
                 append(' ')
                 buildMarkdownAnnotatedString(content, child.children.innerList())
                 append(' ')


### PR DESCRIPTION
- introduce new API to pass `inlineCodeText` color differently from `codeText` color
  - FIX https://github.com/mikepenz/multiplatform-markdown-renderer/issues/130