### PR TITLE
Fix text following a link is still clickable

### DIFF
--- a/compose-desktop/src/main/kotlin/main.kt
+++ b/compose-desktop/src/main/kotlin/main.kt
@@ -34,7 +34,7 @@ fun main() = application {
                 }
                 ```
                 
-                You can find more information on [GitHub](https://github.com/mikepenz/multiplatform-markdown-renderer).
+                You can find more information on [GitHub](https://github.com/mikepenz/multiplatform-markdown-renderer). More Text after this.
                 
                 ![Image](https://avatars.githubusercontent.com/u/1476232?v=4)
                 

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
@@ -30,6 +30,7 @@ internal fun AnnotatedString.Builder.appendMarkdownLink(content: String, node: A
     pushStyle(SpanStyle(color = LocalMarkdownColors.current.linkText, textDecoration = TextDecoration.Underline, fontWeight = FontWeight.Bold))
     buildMarkdownAnnotatedString(content, linkText)
     pop()
+    pop()
 }
 
 internal fun AnnotatedString.Builder.appendAutoLink(content: String, node: ASTNode) {


### PR DESCRIPTION
- ensure the link can not be clicked after the link text itself ends due to a missed `pop()`
  - relates to: https://github.com/mikepenz/multiplatform-markdown-renderer/pull/129