### PR TITLE
Use the correct color for the `divider` 

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownDivider.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownDivider.kt
@@ -16,7 +16,7 @@ import com.mikepenz.markdown.compose.LocalMarkdownDimens
 @Composable
 fun MarkdownDivider(
     modifier: Modifier = Modifier,
-    color: Color = LocalMarkdownColors.current.codeBackground,
+    color: Color = LocalMarkdownColors.current.dividerColor,
     thickness: Dp = LocalMarkdownDimens.current.dividerThickness,
 ) {
     val targetThickness = if (thickness == Dp.Hairline) {


### PR DESCRIPTION
- use the `dividerColor` for the `MarkdownDivider`
  - FIX https://github.com/mikepenz/multiplatform-markdown-renderer/issues/131