### PR TITLE
Add support for `extended-spans` - Improved looks for inline code, animated underlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ dependencies {
 </details>
 
 > [!TIP]
-> Since 0.13.0 the core library does not depend on a Material theme anymore. Include the `-m2` or `-m3` module to get
+> Since 0.13.0 the core library does not depend on a Material theme anymore. Include the `-m2`
+> or `-m3` module to get
 > access to the defaults.
 
 
@@ -121,6 +122,35 @@ Markdown(
 )
 ```
 
+### Extended spans
+
+Starting with 0.16.0 the library includes support
+for [extended-spans](https://github.com/saket/extended-spans).
+> The library was integrated to to make it multiplatform compatible. All credits for its
+> functionality goes to [
+Saket Narayan](https://github.com/saket).
+
+It is not enabled by default, however you can enable it quickly by configuring the `extendedSpans`
+for your `Markdown` composeable.
+Define the `ExtendedSpans` you want to apply (including optionally your own custom ones) and return
+it.
+
+```kotlin
+Markdown(
+    content,
+    extendedSpans = markdownExtendedSpans {
+        val animator = rememberSquigglyUnderlineAnimator()
+        remember {
+            ExtendedSpans(
+                RoundedCornerSpanPainter(),
+                SquigglyUnderlineSpanPainter(animator = animator)
+            )
+        }
+    },
+    modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(16.dp)
+)
+```
+
 ### Adjust List Ordering
 
 ```kotlin
@@ -142,7 +172,8 @@ This can be done by providing the components `MarkdownComponents` to the `Markdo
 
 Use the `markdownComponents()` to keep defaults for non overwritten components.
 
-The `MarkdownComponent` will expose access to the `content: String`, `node: ASTNode`, `typography: MarkdownTypography`,
+The `MarkdownComponent` will expose access to
+the `content: String`, `node: ASTNode`, `typography: MarkdownTypography`,
 offering full flexibility.
 
 ```kotlin
@@ -185,18 +216,20 @@ Markdown(
 
 In the current versions of the library, image loading is included in different variants.
 
-- Android: Uses `coil` to load images (Default configuration). The global `ImageLoader` is respected. 
+- Android: Uses `coil` to load images (Default configuration). The global `ImageLoader` is
+  respected.
 - JVM: Load image as HTTPUrlConnection and set to the view
 - JS / Native: No image loading provided at this time
 
-Provide your own `ImageTransformer` to the `Markdown` compose function to modify this behavior. 
+Provide your own `ImageTransformer` to the `Markdown` compose function to modify this behavior.
 
 > [!NOTE]  
 > It is planned to update to coil3 for all platforms once it reaches a more stable release cycle.
 
 ## Dependency
 
-This project uses JetBrains [markdown](https://github.com/JetBrains/markdown/) Multiplatform Markdown processor as
+This project uses JetBrains [markdown](https://github.com/JetBrains/markdown/) Multiplatform
+Markdown processor as
 dependency to parse the markdown content.
 
 ## Developed By
@@ -207,20 +240,27 @@ dependency to parse the markdown content.
 
 ## Contributors
 
-This free, open source software was also made possible by a group of volunteers that put many hours of hard work into
+This free, open source software was also made possible by a group of volunteers that put many hours
+of hard work into
 it. See the [CONTRIBUTORS.md](CONTRIBUTORS.md) file for details.
 
 ## Credits
 
 Big thanks to [Erik Hellman](https://twitter.com/ErikHellman) and his awesome article
-on [Rendering Markdown with Jetpack Compose](https://www.hellsoft.se/rendering-markdown-with-jetpack-compose/), and the
-related source [MarkdownComposer](https://github.com/ErikHellman/MarkdownComposer).
+on [Rendering Markdown with Jetpack Compose](https://www.hellsoft.se/rendering-markdown-with-jetpack-compose/),
+and the related source [MarkdownComposer](https://github.com/ErikHellman/MarkdownComposer).
+
+Also huge thanks to [Saket Narayan](https://github.com/saket/) for his great work on
+the [extended-spans](https://github.com/saket/extended-spans) project. Ported into this project to
+make it multiplatform.
 
 ## Fork License
 
 Copyright for portions of the code are held by [Erik Hellman, 2020] as part of
-project [MarkdownComposer](https://github.com/ErikHellman/MarkdownComposer) under the MIT license. All other copyright
-for project multiplatform-markdown-renderer are held by [Mike Penz, 2023] under the Apache License, Version 2.0.
+project [MarkdownComposer](https://github.com/ErikHellman/MarkdownComposer) under the MIT license.
+All other copyright
+for project multiplatform-markdown-renderer are held by [Mike Penz, 2023] under the Apache License,
+Version 2.0.
 
 ## License
 

--- a/compose-desktop/src/main/kotlin/main.kt
+++ b/compose-desktop/src/main/kotlin/main.kt
@@ -5,11 +5,17 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
+import com.mikepenz.markdown.compose.extendedspans.ExtendedSpans
+import com.mikepenz.markdown.compose.extendedspans.RoundedCornerSpanPainter
+import com.mikepenz.markdown.compose.extendedspans.SquigglyUnderlineSpanPainter
+import com.mikepenz.markdown.compose.extendedspans.rememberSquigglyUnderlineAnimator
 import com.mikepenz.markdown.m2.Markdown
+import com.mikepenz.markdown.model.markdownExtendedSpans
 
 fun main() = application {
     Window(onCloseRequest = ::exitApplication, title = "Markdown Sample") {
@@ -40,7 +46,6 @@ fun main() = application {
                 
                 There are many more things which can be experimented with like, inline `code`. 
                 
-                
                 Title 1
                 ======
                 
@@ -51,8 +56,18 @@ fun main() = application {
                 [https://github.com/mikepenz](https://github.com/mikepenz)
                 [Mike Penz's Blog](https://blog.mikepenz.dev/)
                 """.trimIndent()
+
                 Markdown(
                     content,
+                    extendedSpans = markdownExtendedSpans {
+                        val animator = rememberSquigglyUnderlineAnimator()
+                        remember {
+                            ExtendedSpans(
+                                RoundedCornerSpanPainter(),
+                                SquigglyUnderlineSpanPainter(animator = animator)
+                            )
+                        }
+                    },
                     modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(16.dp)
                 )
             }

--- a/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/Markdown.kt
+++ b/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/Markdown.kt
@@ -5,7 +5,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.markdownComponents
-import com.mikepenz.markdown.model.*
+import com.mikepenz.markdown.model.ImageTransformer
+import com.mikepenz.markdown.model.ImageTransformerImpl
+import com.mikepenz.markdown.model.MarkdownColors
+import com.mikepenz.markdown.model.MarkdownDimens
+import com.mikepenz.markdown.model.MarkdownExtendedSpans
+import com.mikepenz.markdown.model.MarkdownPadding
+import com.mikepenz.markdown.model.MarkdownTypography
+import com.mikepenz.markdown.model.markdownDimens
+import com.mikepenz.markdown.model.markdownExtendedSpans
+import com.mikepenz.markdown.model.markdownPadding
 import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 
@@ -19,6 +28,7 @@ fun Markdown(
     dimens: MarkdownDimens = markdownDimens(),
     flavour: MarkdownFlavourDescriptor = GFMFlavourDescriptor(),
     imageTransformer: ImageTransformer = ImageTransformerImpl(),
+    extendedSpans: MarkdownExtendedSpans = markdownExtendedSpans(),
     components: MarkdownComponents = markdownComponents(),
 ) = com.mikepenz.markdown.compose.Markdown(
     content,
@@ -29,5 +39,6 @@ fun Markdown(
     dimens,
     flavour,
     imageTransformer,
+    extendedSpans,
     components,
 )

--- a/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/Markdown.kt
+++ b/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/Markdown.kt
@@ -5,7 +5,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.markdownComponents
-import com.mikepenz.markdown.model.*
+import com.mikepenz.markdown.model.ImageTransformer
+import com.mikepenz.markdown.model.ImageTransformerImpl
+import com.mikepenz.markdown.model.MarkdownColors
+import com.mikepenz.markdown.model.MarkdownDimens
+import com.mikepenz.markdown.model.MarkdownExtendedSpans
+import com.mikepenz.markdown.model.MarkdownPadding
+import com.mikepenz.markdown.model.MarkdownTypography
+import com.mikepenz.markdown.model.markdownDimens
+import com.mikepenz.markdown.model.markdownExtendedSpans
+import com.mikepenz.markdown.model.markdownPadding
 import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 
@@ -19,6 +28,7 @@ fun Markdown(
     dimens: MarkdownDimens = markdownDimens(),
     flavour: MarkdownFlavourDescriptor = GFMFlavourDescriptor(),
     imageTransformer: ImageTransformer = ImageTransformerImpl(),
+    extendedSpans: MarkdownExtendedSpans = markdownExtendedSpans(),
     components: MarkdownComponents = markdownComponents(),
 ) = com.mikepenz.markdown.compose.Markdown(
     content,
@@ -29,5 +39,6 @@ fun Markdown(
     dimens,
     flavour,
     imageTransformer,
+    extendedSpans,
     components,
 )

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/ComposeLocal.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/ComposeLocal.kt
@@ -2,7 +2,15 @@ package com.mikepenz.markdown.compose
 
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
-import com.mikepenz.markdown.model.*
+import com.mikepenz.markdown.model.BulletHandler
+import com.mikepenz.markdown.model.DefaultMarkdownExtendedSpans
+import com.mikepenz.markdown.model.ImageTransformer
+import com.mikepenz.markdown.model.MarkdownColors
+import com.mikepenz.markdown.model.MarkdownDimens
+import com.mikepenz.markdown.model.MarkdownExtendedSpans
+import com.mikepenz.markdown.model.MarkdownPadding
+import com.mikepenz.markdown.model.MarkdownTypography
+import com.mikepenz.markdown.model.ReferenceLinkHandler
 
 /**
  * The CompositionLocal to provide functionality related to transforming the bullet of an ordered list
@@ -53,10 +61,16 @@ val LocalMarkdownDimens = compositionLocalOf<MarkdownDimens> {
     error("No local MarkdownDimens")
 }
 
-
 /**
  * Local [ImageTransformer] provider
  */
 val LocalImageTransformer = staticCompositionLocalOf<ImageTransformer> {
     error("No local ImageTransformer")
+}
+
+/**
+ * Local [MarkdownExtendedSpans] provider
+ */
+val LocalMarkdownExtendedSpans = compositionLocalOf<MarkdownExtendedSpans> {
+    return@compositionLocalOf DefaultMarkdownExtendedSpans(null)
 }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
@@ -1,13 +1,27 @@
 package com.mikepenz.markdown.compose
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import com.mikepenz.markdown.compose.components.MarkdownComponentModel
 import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.markdownComponents
-import com.mikepenz.markdown.model.*
+import com.mikepenz.markdown.model.ImageTransformer
+import com.mikepenz.markdown.model.ImageTransformerImpl
+import com.mikepenz.markdown.model.MarkdownColors
+import com.mikepenz.markdown.model.MarkdownDimens
+import com.mikepenz.markdown.model.MarkdownExtendedSpans
+import com.mikepenz.markdown.model.MarkdownPadding
+import com.mikepenz.markdown.model.MarkdownTypography
+import com.mikepenz.markdown.model.ReferenceLinkHandlerImpl
+import com.mikepenz.markdown.model.markdownDimens
+import com.mikepenz.markdown.model.markdownExtendedSpans
+import com.mikepenz.markdown.model.markdownPadding
 import org.intellij.markdown.MarkdownElementTypes.ATX_1
 import org.intellij.markdown.MarkdownElementTypes.ATX_2
 import org.intellij.markdown.MarkdownElementTypes.ATX_3
@@ -42,6 +56,7 @@ fun Markdown(
     dimens: MarkdownDimens = markdownDimens(),
     flavour: MarkdownFlavourDescriptor = GFMFlavourDescriptor(),
     imageTransformer: ImageTransformer = ImageTransformerImpl(),
+    extendedSpans: MarkdownExtendedSpans = markdownExtendedSpans(),
     components: MarkdownComponents = markdownComponents(),
 ) {
     CompositionLocalProvider(
@@ -50,7 +65,8 @@ fun Markdown(
         LocalMarkdownDimens provides dimens,
         LocalMarkdownColors provides colors,
         LocalMarkdownTypography provides typography,
-        LocalImageTransformer provides imageTransformer
+        LocalImageTransformer provides imageTransformer,
+        LocalMarkdownExtendedSpans provides extendedSpans
     ) {
         Column(modifier) {
             val parsedTree = MarkdownParser(flavour).buildMarkdownTreeFromString(content)
@@ -66,7 +82,11 @@ fun Markdown(
 }
 
 @Composable
-private fun ColumnScope.handleElement(node: ASTNode, components: MarkdownComponents, content: String): Boolean {
+private fun ColumnScope.handleElement(
+    node: ASTNode,
+    components: MarkdownComponents,
+    content: String
+): Boolean {
     val model = MarkdownComponentModel(
         content = content,
         node = node,
@@ -99,7 +119,7 @@ private fun ColumnScope.handleElement(node: ASTNode, components: MarkdownCompone
         }
     }
 
-    if(!handled) {
+    if (!handled) {
         node.children.forEach { child ->
             handleElement(child, components, content)
         }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownParagraph.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownParagraph.kt
@@ -13,12 +13,17 @@ fun MarkdownParagraph(
     content: String,
     node: ASTNode,
     modifier: Modifier = Modifier,
-    style: TextStyle = LocalMarkdownTypography.current.paragraph
+    style: TextStyle = LocalMarkdownTypography.current.paragraph,
 ) {
     val styledText = buildAnnotatedString {
         pushStyle(style.toSpanStyle())
         buildMarkdownAnnotatedString(content, node)
         pop()
     }
-    MarkdownText(styledText, modifier = modifier, style = style)
+
+    MarkdownText(
+        styledText,
+        modifier = modifier,
+        style = style,
+    )
 }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/ExtendedSpanPainter.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/ExtendedSpanPainter.kt
@@ -1,0 +1,93 @@
+// Copyright 2023, Saket Narayan
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/saket/extended-spans
+package com.mikepenz.markdown.compose.extendedspans
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.style.ResolvedTextDirection.Ltr
+import com.mikepenz.markdown.compose.extendedspans.internal.fastMapRange
+
+abstract class ExtendedSpanPainter {
+    /**
+     * Can be used for removing any existing spans from [text] so that they can be drawn manually.
+     */
+    abstract fun decorate(
+        span: SpanStyle,
+        start: Int,
+        end: Int,
+        text: AnnotatedString,
+        builder: AnnotatedString.Builder
+    ): SpanStyle
+
+    abstract fun drawInstructionsFor(
+        layoutResult: TextLayoutResult
+    ): SpanDrawInstructions
+
+    /**
+     * Reads bounds for multiple lines. This can be removed once an
+     * [official API](https://issuetracker.google.com/u/1/issues/237289433) is released.
+     *
+     * When [flattenForFullParagraphs] is available, the bounds for one or multiple
+     * entire paragraphs is returned instead of separate lines if [startOffset]
+     * and [endOffset] represent the extreme ends of those paragraph.
+     */
+    protected fun TextLayoutResult.getBoundingBoxes(
+        startOffset: Int,
+        endOffset: Int,
+        flattenForFullParagraphs: Boolean = false
+    ): List<Rect> {
+        if (startOffset == endOffset) {
+            return emptyList()
+        }
+
+        val startLineNum = getLineForOffset(startOffset)
+        val endLineNum = getLineForOffset(endOffset)
+
+        if (flattenForFullParagraphs) {
+            val isFullParagraph = (startLineNum != endLineNum)
+                    && getLineStart(startLineNum) == startOffset
+                    && multiParagraph.getLineEnd(endLineNum, visibleEnd = true) == endOffset
+
+            if (isFullParagraph) {
+                return listOf(
+                    Rect(
+                        top = getLineTop(startLineNum),
+                        bottom = getLineBottom(endLineNum),
+                        left = 0f,
+                        right = size.width.toFloat()
+                    )
+                )
+            }
+        }
+
+        // Compose UI does not offer any API for reading paragraph direction for an entire line.
+        // So this code assumes that all paragraphs in the text will have the same direction.
+        // It also assumes that this paragraph does not contain bi-directional text.
+        val isLtr = multiParagraph.getParagraphDirection(offset = layoutInput.text.lastIndex) == Ltr
+
+        return fastMapRange(startLineNum, endLineNum) { lineNum ->
+            Rect(
+                top = getLineTop(lineNum),
+                bottom = getLineBottom(lineNum),
+                left = if (lineNum == startLineNum) {
+                    getHorizontalPosition(startOffset, usePrimaryDirection = isLtr)
+                } else {
+                    getLineLeft(lineNum)
+                },
+                right = if (lineNum == endLineNum) {
+                    getHorizontalPosition(endOffset, usePrimaryDirection = isLtr)
+                } else {
+                    getLineRight(lineNum)
+                }
+            )
+        }
+    }
+}
+
+fun interface SpanDrawInstructions {
+    fun DrawScope.draw()
+}

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/ExtendedSpans.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/ExtendedSpans.kt
@@ -1,0 +1,97 @@
+// Copyright 2023, Saket Narayan
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/saket/extended-spans
+@file:OptIn(ExperimentalTextApi::class)
+
+package com.mikepenz.markdown.compose.extendedspans
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.buildAnnotatedString
+import com.mikepenz.markdown.compose.extendedspans.internal.fastFold
+import com.mikepenz.markdown.compose.extendedspans.internal.fastForEach
+import com.mikepenz.markdown.compose.extendedspans.internal.fastMap
+
+@Stable
+class ExtendedSpans(
+    vararg painters: ExtendedSpanPainter
+) {
+    private val painters = painters.toList()
+    internal var drawInstructions = emptyList<SpanDrawInstructions>()
+
+    /**
+     * Prepares [text] to be rendered by [painters]. [RoundedCornerSpanPainter] and [SquigglyUnderlineSpanPainter]
+     * use this for removing background and underline spans so that they can be drawn manually.
+     */
+    fun extend(text: AnnotatedString): AnnotatedString {
+        return buildAnnotatedString {
+            append(text.text)
+
+            // For onTextLayout to be called if a new instance of ExtendedSpans is applied with the same text.
+            val uniqueKey = this@ExtendedSpans.hashCode().toString()
+            addStringAnnotation(
+                EXTENDED_SPANS_MARKER_TAG,
+                annotation = uniqueKey,
+                start = 0,
+                end = 0
+            )
+
+            text.spanStyles.fastForEach {
+                val decorated = painters.fastFold(initial = it.item) { updated, painter ->
+                    painter.decorate(updated, it.start, it.end, text = text, builder = this)
+                }
+                addStyle(decorated, it.start, it.end)
+            }
+            text.paragraphStyles.fastForEach {
+                addStyle(it.item, it.start, it.end)
+            }
+            text.getStringAnnotations(start = 0, end = text.length).fastForEach {
+                addStringAnnotation(
+                    tag = it.tag,
+                    annotation = it.item,
+                    start = it.start,
+                    end = it.end
+                )
+            }
+            text.getTtsAnnotations(start = 0, end = text.length).fastForEach {
+                addTtsAnnotation(it.item, it.start, it.end)
+            }
+        }
+    }
+
+    fun onTextLayout(layoutResult: TextLayoutResult) {
+        layoutResult.checkIfExtendWasCalled()
+        drawInstructions = painters.fastMap {
+            it.drawInstructionsFor(layoutResult)
+        }
+    }
+
+    private fun TextLayoutResult.checkIfExtendWasCalled() {
+        val wasExtendCalled = layoutInput.text.getStringAnnotations(
+            tag = EXTENDED_SPANS_MARKER_TAG,
+            start = 0,
+            end = 0
+        ).isNotEmpty()
+        check(wasExtendCalled) {
+            "ExtendedSpans#extend(AnnotatedString) wasn't called for this Text()."
+        }
+    }
+
+    companion object {
+        private const val EXTENDED_SPANS_MARKER_TAG = "extended_spans_marker"
+    }
+}
+
+fun Modifier.drawBehind(spans: ExtendedSpans): Modifier {
+    return drawBehind {
+        spans.drawInstructions.fastForEach { instructions ->
+            with(instructions) {
+                draw()
+            }
+        }
+    }
+}

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/RoundedCornerSpanPainter.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/RoundedCornerSpanPainter.kt
@@ -1,0 +1,126 @@
+// Copyright 2023, Saket Narayan
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/saket/extended-spans
+package com.mikepenz.markdown.compose.extendedspans
+
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.isUnspecified
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+import com.mikepenz.markdown.compose.extendedspans.internal.deserializeToColor
+import com.mikepenz.markdown.compose.extendedspans.internal.fastForEach
+import com.mikepenz.markdown.compose.extendedspans.internal.fastForEachIndexed
+import com.mikepenz.markdown.compose.extendedspans.internal.serialize
+
+/**
+ * Draws round rectangles behind text annotated using `SpanStyle(background = …)`.
+ *
+ * [topMargin] and [bottomMargin] are placeholder values that will be automatically calculated from font metrics
+ * in the future once Compose UI starts exposing them ([Issue tracker](https://issuetracker.google.com/u/1/issues/237428541)).
+ * In the meantime, you can calculate these depending upon your text's font size and line height.
+ */
+class RoundedCornerSpanPainter(
+    private val cornerRadius: TextUnit = 8.sp,
+    private val stroke: Stroke? = null,
+    private val padding: TextPaddingValues = TextPaddingValues(horizontal = 2.sp, vertical = 2.sp),
+    private val topMargin: TextUnit = 1.sp,
+    private val bottomMargin: TextUnit = 1.sp,
+) : ExtendedSpanPainter() {
+    private val path = Path()
+
+    override fun decorate(
+        span: SpanStyle,
+        start: Int,
+        end: Int,
+        text: AnnotatedString,
+        builder: AnnotatedString.Builder
+    ): SpanStyle {
+        return if (span.background.isUnspecified) {
+            span
+        } else {
+            builder.addStringAnnotation(
+                TAG,
+                annotation = span.background.serialize(),
+                start = start,
+                end = end
+            )
+            span.copy(background = Color.Unspecified)
+        }
+    }
+
+    override fun drawInstructionsFor(layoutResult: TextLayoutResult): SpanDrawInstructions {
+        val text = layoutResult.layoutInput.text
+        val annotations = text.getStringAnnotations(TAG, start = 0, end = text.length)
+
+        return SpanDrawInstructions {
+            val cornerRadius = CornerRadius(cornerRadius.toPx())
+
+            annotations.fastForEach { annotation ->
+                val backgroundColor = annotation.item.deserializeToColor()!!
+                val boxes = layoutResult.getBoundingBoxes(
+                    startOffset = annotation.start,
+                    endOffset = annotation.end,
+                    flattenForFullParagraphs = true
+                )
+                boxes.fastForEachIndexed { index, box ->
+                    path.rewind()
+                    path.addRoundRect(
+                        RoundRect(
+                            rect = box.copy(
+                                left = box.left - padding.horizontal.toPx(),
+                                right = box.right + padding.horizontal.toPx(),
+                                top = box.top - padding.vertical.toPx() + topMargin.toPx(),
+                                bottom = box.bottom + padding.vertical.toPx() - bottomMargin.toPx(),
+                            ),
+                            topLeft = if (index == 0) cornerRadius else CornerRadius.Zero,
+                            bottomLeft = if (index == 0) cornerRadius else CornerRadius.Zero,
+                            topRight = if (index == boxes.lastIndex) cornerRadius else CornerRadius.Zero,
+                            bottomRight = if (index == boxes.lastIndex) cornerRadius else CornerRadius.Zero
+                        )
+                    )
+                    drawPath(
+                        path = path,
+                        color = backgroundColor,
+                        style = Fill
+                    )
+                    if (stroke != null) {
+                        drawPath(
+                            path = path,
+                            color = stroke.color(backgroundColor),
+                            style = Stroke(
+                                width = stroke.width.toPx(),
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    data class Stroke(
+        val color: (background: Color) -> Color,
+        val width: TextUnit = 1.sp
+    ) {
+        constructor(color: Color, width: TextUnit = 1.sp) : this(
+            color = { color },
+            width = width
+        )
+    }
+
+    data class TextPaddingValues(
+        val horizontal: TextUnit = 0.sp,
+        val vertical: TextUnit = 0.sp
+    )
+
+    companion object {
+        private const val TAG = "rounded_corner_span"
+    }
+}

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/SquigglyUnderlineSpanPainter.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/SquigglyUnderlineSpanPainter.kt
@@ -1,0 +1,189 @@
+// Copyright 2023, Saket Narayan
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/saket/extended-spans
+@file:Suppress("NAME_SHADOWING")
+
+package com.mikepenz.markdown.compose.extendedspans
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.style.TextDecoration.Companion.LineThrough
+import androidx.compose.ui.text.style.TextDecoration.Companion.None
+import androidx.compose.ui.text.style.TextDecoration.Companion.Underline
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+import com.mikepenz.markdown.compose.extendedspans.internal.deserializeToColor
+import com.mikepenz.markdown.compose.extendedspans.internal.fastFirstOrNull
+import com.mikepenz.markdown.compose.extendedspans.internal.fastForEach
+import com.mikepenz.markdown.compose.extendedspans.internal.fastMapRange
+import com.mikepenz.markdown.compose.extendedspans.internal.serialize
+import kotlin.math.PI
+import kotlin.math.ceil
+import kotlin.math.sin
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Draws squiggly underlines below text annotated using `SpanStyle(textDecoration = Underline)`.
+ * Inspired from [Sam Ruston's BuzzKill app](https://twitter.com/saketme/status/1310073763019530242).
+ *
+ * ```
+ *
+ *       _....._                                     _....._         ▲
+ *    ,="       "=.                               ,="       "=.   amplitude
+ *  ,"             ".                           ,"             ".    │
+ *,"                 ".,                     ,,"                 "., ▼
+ *""""""""""|""""""""""|."""""""""|""""""""".|""""""""""|""""""""""|
+ *                       ".               ."
+ *                         "._         _,"
+ *                            "-.....-"
+ *◀─────────────── Wavelength ──────────────▶
+ *
+ * ```
+ *
+ * @param animator See [rememberSquigglyUnderlineAnimator].
+ * @param bottomOffset Distance from a line's bottom coordinate.
+ */
+class SquigglyUnderlineSpanPainter(
+    private val width: TextUnit = 2.sp,
+    private val wavelength: TextUnit = 9.sp,
+    private val amplitude: TextUnit = 1.sp,
+    private val bottomOffset: TextUnit = 1.sp,
+    private val animator: SquigglyUnderlineAnimator = SquigglyUnderlineAnimator.NoOp,
+) : ExtendedSpanPainter() {
+    private val path = Path()
+
+    override fun decorate(
+        span: SpanStyle,
+        start: Int,
+        end: Int,
+        text: AnnotatedString,
+        builder: AnnotatedString.Builder
+    ): SpanStyle {
+        val textDecoration = span.textDecoration
+        return if (textDecoration == null || Underline !in textDecoration) {
+            span
+        } else {
+            val textColor = text.spanStyles.fastFirstOrNull {
+                // I don't think this predicate will work for text annotated with overlapping
+                // multiple colors, but I'm not too interested in solving for that use case.
+                it.start <= start && it.end >= end && it.item.color.isSpecified
+            }?.item?.color ?: Color.Unspecified
+
+            builder.addStringAnnotation(
+                TAG,
+                annotation = textColor.serialize(),
+                start = start,
+                end = end
+            )
+            span.copy(textDecoration = if (LineThrough in textDecoration) LineThrough else None)
+        }
+    }
+
+    override fun drawInstructionsFor(layoutResult: TextLayoutResult): SpanDrawInstructions {
+        val text = layoutResult.layoutInput.text
+        val annotations = text.getStringAnnotations(TAG, start = 0, end = text.length)
+
+        return SpanDrawInstructions {
+            val pathStyle = Stroke(
+                width = width.toPx(),
+                join = StrokeJoin.Round,
+                cap = StrokeCap.Round,
+                pathEffect = PathEffect.cornerPathEffect(radius = wavelength.toPx()), // For slightly smoother waves.
+            )
+
+            annotations.fastForEach { annotation ->
+                val boxes = layoutResult.getBoundingBoxes(
+                    startOffset = annotation.start,
+                    endOffset = annotation.end
+                )
+                val textColor =
+                    annotation.item.deserializeToColor() ?: layoutResult.layoutInput.style.color
+                boxes.fastForEach { box ->
+                    path.rewind()
+                    path.buildSquigglesFor(box, density = this)
+                    drawPath(
+                        path = path,
+                        color = textColor,
+                        style = pathStyle
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Maths copied from [squigglyspans](https://github.com/samruston/squigglyspans).
+     */
+    private fun Path.buildSquigglesFor(box: Rect, density: Density) = density.run {
+        val lineStart = box.left + (width.toPx() / 2)
+        val lineEnd = box.right - (width.toPx() / 2)
+        val lineBottom = box.bottom + bottomOffset.toPx()
+
+        val segmentWidth = wavelength.toPx() / SEGMENTS_PER_WAVELENGTH
+        val numOfPoints = ceil((lineEnd - lineStart) / segmentWidth).toInt() + 1
+
+        var pointX = lineStart
+        fastMapRange(0, numOfPoints) { point ->
+            val proportionOfWavelength = (pointX - lineStart) / wavelength.toPx()
+            val radiansX =
+                proportionOfWavelength * TWO_PI + (TWO_PI * animator.animationProgress.value)
+            val offsetY = lineBottom + (sin(radiansX) * amplitude.toPx())
+
+            when (point) {
+                0 -> moveTo(pointX, offsetY)
+                else -> lineTo(pointX, offsetY)
+            }
+            pointX = (pointX + segmentWidth).coerceAtMost(lineEnd)
+        }
+    }
+
+    companion object {
+        private const val TAG = "squiggly_underline_span"
+        private const val SEGMENTS_PER_WAVELENGTH = 10
+        private const val TWO_PI = 2 * PI.toFloat()
+    }
+}
+
+@Composable
+fun rememberSquigglyUnderlineAnimator(duration: Duration = 1.seconds): SquigglyUnderlineAnimator {
+    val animationProgress = rememberInfiniteTransition().animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(duration.inWholeMilliseconds.toInt(), easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        )
+    )
+    return remember {
+        SquigglyUnderlineAnimator(animationProgress)
+    }
+}
+
+@Stable
+class SquigglyUnderlineAnimator internal constructor(internal val animationProgress: State<Float>) {
+    companion object {
+        val NoOp = SquigglyUnderlineAnimator(animationProgress = mutableStateOf(0f))
+    }
+}

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/internal/ColorSerializers.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/internal/ColorSerializers.kt
@@ -1,0 +1,16 @@
+// Copyright 2023, Saket Narayan
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/saket/extended-spans
+package com.mikepenz.markdown.compose.extendedspans.internal
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.isUnspecified
+import androidx.compose.ui.graphics.toArgb
+
+fun Color?.serialize(): String {
+    return if (this == null || isUnspecified) "null" else "${toArgb()}"
+}
+
+fun String.deserializeToColor(): Color? {
+    return if (this == "null") null else Color(this.toInt())
+}

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/internal/Lists.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/internal/Lists.kt
@@ -1,0 +1,83 @@
+// Copyright 2023, Saket Narayan
+// SPDX-License-Identifier: Apache-2.0
+// https://github.com/saket/extended-spans
+package com.mikepenz.markdown.compose.extendedspans.internal
+
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+/**
+ * Copied from [androidx](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:text/text/src/main/java/androidx/compose/ui/text/android/TempListUtils.kt;l=33;drc=b2e3d878411b7fb1147455b1a204cddb7bee1a1b).
+ */
+@OptIn(ExperimentalContracts::class)
+internal inline fun <T> List<T>.fastForEach(action: (T) -> Unit) {
+    contract { callsInPlace(action) }
+    for (index in indices) {
+        val item = get(index)
+        action(item)
+    }
+}
+
+@OptIn(ExperimentalContracts::class)
+internal inline fun <T> List<T>.fastForEachIndexed(action: (index: Int, T) -> Unit) {
+    contract { callsInPlace(action) }
+    for (index in indices) {
+        val item = get(index)
+        action(index, item)
+    }
+}
+
+@OptIn(ExperimentalContracts::class)
+internal inline fun <T> List<T>.fastFirstOrNull(predicate: (T) -> Boolean): T? {
+    contract { callsInPlace(predicate) }
+    for (index in indices) {
+        val item = get(index)
+        if (predicate(item)) {
+            return item
+        }
+    }
+    return null
+}
+
+/**
+ * Copied from [androidx](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:text/text/src/main/java/androidx/compose/ui/text/android/TempListUtils.kt;l=50;drc=b2e3d878411b7fb1147455b1a204cddb7bee1a1b).
+ */
+@OptIn(ExperimentalContracts::class)
+internal inline fun <T, R> List<T>.fastMap(
+    transform: (T) -> R
+): List<R> {
+    contract { callsInPlace(transform) }
+    val destination = ArrayList<R>(/* initialCapacity = */ size)
+    fastForEach { item ->
+        destination.add(transform(item))
+    }
+    return destination
+}
+
+/**
+ * Copied from [androidx](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/TempListUtils.kt;l=107;drc=ceaa7640c065146360515e598a3d09f6f66553dd).
+ */
+@Suppress("BanInlineOptIn") // Treat Kotlin Contracts as non-experimental.
+@OptIn(ExperimentalContracts::class)
+internal inline fun <T, R> List<T>.fastFold(initial: R, operation: (acc: R, T) -> R): R {
+    contract { callsInPlace(operation) }
+    var accumulator = initial
+    fastForEach { e ->
+        accumulator = operation(accumulator, e)
+    }
+    return accumulator
+}
+
+@OptIn(ExperimentalContracts::class)
+internal inline fun <R> fastMapRange(
+    start: Int,
+    end: Int,
+    transform: (Int) -> R
+): List<R> {
+    contract { callsInPlace(transform) }
+    val destination = ArrayList<R>(/* initialCapacity = */ end - start + 1)
+    for (i in start..end) {
+        destination.add(transform(i))
+    }
+    return destination
+}

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownExtendedSpans.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownExtendedSpans.kt
@@ -1,0 +1,21 @@
+package com.mikepenz.markdown.model
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import com.mikepenz.markdown.compose.extendedspans.ExtendedSpans
+
+interface MarkdownExtendedSpans {
+    val extendedSpans: (@Composable () -> ExtendedSpans)?
+}
+
+@Immutable
+class DefaultMarkdownExtendedSpans(
+    override val extendedSpans: (@Composable () -> ExtendedSpans)?
+) : MarkdownExtendedSpans
+
+@Composable
+fun markdownExtendedSpans(
+    extendedSpans: (@Composable () -> ExtendedSpans)? = null
+): MarkdownExtendedSpans = DefaultMarkdownExtendedSpans(
+    extendedSpans
+)


### PR DESCRIPTION
- introduce first draft of extended-spans by porting https://github.com/saket/extended-spans into this library
  - Offer ability to define extended spans for the Markdown class used by the internal text component


This solves: https://github.com/mikepenz/multiplatform-markdown-renderer/issues/132
Thanks @saket for the great work on the `extended-spans` library. 