### PR TITLE
Add ability to overwrite the annotated string building logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,26 @@ Markdown(
                 SquigglyUnderlineSpanPainter(animator = animator)
             )
         }
-    },
-    modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(16.dp)
+    }
+)
+```
+
+### Extend Annotated string handling
+
+The library already handles a significant amount of different tokens, however not all. To allow
+special integrations expand this, you can pass in a custom `annotator` to the `Markdown`
+composeable. This `annotator` allows you to customize existing handled tokens, but also add new
+ones.
+
+```kotlin
+Markdown(
+    content,
+    annotator = markdownAnnotator { content, child ->
+        if (child.type == GFMElementTypes.STRIKETHROUGH) {
+            append("Replaced you :)")
+            true // return true to consume this ASTNode child
+        } else false
+    }
 )
 ```
 

--- a/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/Markdown.kt
+++ b/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/Markdown.kt
@@ -7,11 +7,13 @@ import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.markdownComponents
 import com.mikepenz.markdown.model.ImageTransformer
 import com.mikepenz.markdown.model.ImageTransformerImpl
+import com.mikepenz.markdown.model.MarkdownAnnotator
 import com.mikepenz.markdown.model.MarkdownColors
 import com.mikepenz.markdown.model.MarkdownDimens
 import com.mikepenz.markdown.model.MarkdownExtendedSpans
 import com.mikepenz.markdown.model.MarkdownPadding
 import com.mikepenz.markdown.model.MarkdownTypography
+import com.mikepenz.markdown.model.markdownAnnotator
 import com.mikepenz.markdown.model.markdownDimens
 import com.mikepenz.markdown.model.markdownExtendedSpans
 import com.mikepenz.markdown.model.markdownPadding
@@ -28,6 +30,7 @@ fun Markdown(
     dimens: MarkdownDimens = markdownDimens(),
     flavour: MarkdownFlavourDescriptor = GFMFlavourDescriptor(),
     imageTransformer: ImageTransformer = ImageTransformerImpl(),
+    annotator: MarkdownAnnotator = markdownAnnotator(),
     extendedSpans: MarkdownExtendedSpans = markdownExtendedSpans(),
     components: MarkdownComponents = markdownComponents(),
 ) = com.mikepenz.markdown.compose.Markdown(
@@ -39,6 +42,7 @@ fun Markdown(
     dimens,
     flavour,
     imageTransformer,
+    annotator,
     extendedSpans,
     components,
 )

--- a/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/Markdown.kt
+++ b/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/Markdown.kt
@@ -7,11 +7,13 @@ import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.markdownComponents
 import com.mikepenz.markdown.model.ImageTransformer
 import com.mikepenz.markdown.model.ImageTransformerImpl
+import com.mikepenz.markdown.model.MarkdownAnnotator
 import com.mikepenz.markdown.model.MarkdownColors
 import com.mikepenz.markdown.model.MarkdownDimens
 import com.mikepenz.markdown.model.MarkdownExtendedSpans
 import com.mikepenz.markdown.model.MarkdownPadding
 import com.mikepenz.markdown.model.MarkdownTypography
+import com.mikepenz.markdown.model.markdownAnnotator
 import com.mikepenz.markdown.model.markdownDimens
 import com.mikepenz.markdown.model.markdownExtendedSpans
 import com.mikepenz.markdown.model.markdownPadding
@@ -28,6 +30,7 @@ fun Markdown(
     dimens: MarkdownDimens = markdownDimens(),
     flavour: MarkdownFlavourDescriptor = GFMFlavourDescriptor(),
     imageTransformer: ImageTransformer = ImageTransformerImpl(),
+    annotator: MarkdownAnnotator = markdownAnnotator(),
     extendedSpans: MarkdownExtendedSpans = markdownExtendedSpans(),
     components: MarkdownComponents = markdownComponents(),
 ) = com.mikepenz.markdown.compose.Markdown(
@@ -39,6 +42,7 @@ fun Markdown(
     dimens,
     flavour,
     imageTransformer,
+    annotator,
     extendedSpans,
     components,
 )

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/ComposeLocal.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/ComposeLocal.kt
@@ -3,8 +3,10 @@ package com.mikepenz.markdown.compose
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
 import com.mikepenz.markdown.model.BulletHandler
+import com.mikepenz.markdown.model.DefaultMarkdownAnnotator
 import com.mikepenz.markdown.model.DefaultMarkdownExtendedSpans
 import com.mikepenz.markdown.model.ImageTransformer
+import com.mikepenz.markdown.model.MarkdownAnnotator
 import com.mikepenz.markdown.model.MarkdownColors
 import com.mikepenz.markdown.model.MarkdownDimens
 import com.mikepenz.markdown.model.MarkdownExtendedSpans
@@ -66,6 +68,13 @@ val LocalMarkdownDimens = compositionLocalOf<MarkdownDimens> {
  */
 val LocalImageTransformer = staticCompositionLocalOf<ImageTransformer> {
     error("No local ImageTransformer")
+}
+
+/**
+ * Local [MarkdownAnnotator] provider
+ */
+val LocalMarkdownAnnotator = compositionLocalOf<MarkdownAnnotator> {
+    return@compositionLocalOf DefaultMarkdownAnnotator(null)
 }
 
 /**

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
@@ -13,12 +13,14 @@ import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.markdownComponents
 import com.mikepenz.markdown.model.ImageTransformer
 import com.mikepenz.markdown.model.ImageTransformerImpl
+import com.mikepenz.markdown.model.MarkdownAnnotator
 import com.mikepenz.markdown.model.MarkdownColors
 import com.mikepenz.markdown.model.MarkdownDimens
 import com.mikepenz.markdown.model.MarkdownExtendedSpans
 import com.mikepenz.markdown.model.MarkdownPadding
 import com.mikepenz.markdown.model.MarkdownTypography
 import com.mikepenz.markdown.model.ReferenceLinkHandlerImpl
+import com.mikepenz.markdown.model.markdownAnnotator
 import com.mikepenz.markdown.model.markdownDimens
 import com.mikepenz.markdown.model.markdownExtendedSpans
 import com.mikepenz.markdown.model.markdownPadding
@@ -56,6 +58,7 @@ fun Markdown(
     dimens: MarkdownDimens = markdownDimens(),
     flavour: MarkdownFlavourDescriptor = GFMFlavourDescriptor(),
     imageTransformer: ImageTransformer = ImageTransformerImpl(),
+    annotator: MarkdownAnnotator = markdownAnnotator(),
     extendedSpans: MarkdownExtendedSpans = markdownExtendedSpans(),
     components: MarkdownComponents = markdownComponents(),
 ) {
@@ -66,6 +69,7 @@ fun Markdown(
         LocalMarkdownColors provides colors,
         LocalMarkdownTypography provides typography,
         LocalImageTransformer provides imageTransformer,
+        LocalMarkdownAnnotator provides annotator,
         LocalMarkdownExtendedSpans provides extendedSpans
     ) {
         Column(modifier) {

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownAnnotator.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownAnnotator.kt
@@ -1,0 +1,28 @@
+package com.mikepenz.markdown.model
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.text.AnnotatedString
+import org.intellij.markdown.ast.ASTNode
+
+interface MarkdownAnnotator {
+    /**
+     * Use the [AnnotatedString.Builder] to build the string to display.
+     * Return `true` to consume the child, false to allow default handling.
+     *
+     * @param content contains the whole content, and requires the `child` [ASTNode] to extract relevant text.
+     */
+    val annotate: (AnnotatedString.Builder.(content: String, child: ASTNode) -> Boolean)?
+}
+
+@Immutable
+class DefaultMarkdownAnnotator(
+    override val annotate: (AnnotatedString.Builder.(content: String, child: ASTNode) -> Boolean)?
+) : MarkdownAnnotator
+
+@Composable
+fun markdownAnnotator(
+    annotate: (AnnotatedString.Builder.(content: String, child: ASTNode) -> Boolean)? = null
+): MarkdownAnnotator = DefaultMarkdownAnnotator(
+    annotate
+)

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import com.mikepenz.markdown.compose.LocalMarkdownAnnotator
 import com.mikepenz.markdown.compose.LocalMarkdownColors
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
@@ -76,76 +77,82 @@ fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, node: 
  */
 @Composable
 fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, children: List<ASTNode>) {
+    val annotator = LocalMarkdownAnnotator.current.annotate
+
     var skipIfNext: Any? = null
     children.forEach { child ->
         if (skipIfNext == null || skipIfNext != child.type) {
-            when (child.type) {
-                MarkdownElementTypes.PARAGRAPH -> buildMarkdownAnnotatedString(content, child)
-                MarkdownElementTypes.IMAGE -> child.findChildOfTypeRecursive(MarkdownElementTypes.LINK_DESTINATION)
-                    ?.let {
-                        appendInlineContent(TAG_IMAGE_URL, it.getTextInNode(content).toString())
+            if (annotator == null || !annotator(content, child)) {
+                when (child.type) {
+                    MarkdownElementTypes.PARAGRAPH -> buildMarkdownAnnotatedString(content, child)
+                    MarkdownElementTypes.IMAGE -> child.findChildOfTypeRecursive(
+                        MarkdownElementTypes.LINK_DESTINATION
+                    )
+                        ?.let {
+                            appendInlineContent(TAG_IMAGE_URL, it.getTextInNode(content).toString())
+                        }
+
+                    MarkdownElementTypes.EMPH -> {
+                        pushStyle(SpanStyle(fontStyle = FontStyle.Italic))
+                        buildMarkdownAnnotatedString(content, child)
+                        pop()
                     }
 
-                MarkdownElementTypes.EMPH -> {
-                    pushStyle(SpanStyle(fontStyle = FontStyle.Italic))
-                    buildMarkdownAnnotatedString(content, child)
-                    pop()
-                }
+                    MarkdownElementTypes.STRONG -> {
+                        pushStyle(SpanStyle(fontWeight = FontWeight.Bold))
+                        buildMarkdownAnnotatedString(content, child)
+                        pop()
+                    }
 
-                MarkdownElementTypes.STRONG -> {
-                    pushStyle(SpanStyle(fontWeight = FontWeight.Bold))
-                    buildMarkdownAnnotatedString(content, child)
-                    pop()
-                }
+                    GFMElementTypes.STRIKETHROUGH -> {
+                        pushStyle(SpanStyle(textDecoration = TextDecoration.LineThrough))
+                        buildMarkdownAnnotatedString(content, child)
+                        pop()
+                    }
 
-                GFMElementTypes.STRIKETHROUGH -> {
-                    pushStyle(SpanStyle(textDecoration = TextDecoration.LineThrough))
-                    buildMarkdownAnnotatedString(content, child)
-                    pop()
-                }
-
-                MarkdownElementTypes.CODE_SPAN -> {
-                    pushStyle(
-                        SpanStyle(
-                            fontFamily = FontFamily.Monospace,
-                            color = LocalMarkdownColors.current.inlineCodeText,
-                            background = LocalMarkdownColors.current.inlineCodeBackground
+                    MarkdownElementTypes.CODE_SPAN -> {
+                        pushStyle(
+                            SpanStyle(
+                                fontFamily = FontFamily.Monospace,
+                                color = LocalMarkdownColors.current.inlineCodeText,
+                                background = LocalMarkdownColors.current.inlineCodeBackground
+                            )
                         )
-                    )
-                    append(' ')
-                    buildMarkdownAnnotatedString(content, child.children.innerList())
-                    append(' ')
-                    pop()
-                }
+                        append(' ')
+                        buildMarkdownAnnotatedString(content, child.children.innerList())
+                        append(' ')
+                        pop()
+                    }
 
-                MarkdownElementTypes.AUTOLINK -> appendAutoLink(content, child)
-                MarkdownElementTypes.INLINE_LINK -> appendMarkdownLink(content, child)
-                MarkdownElementTypes.SHORT_REFERENCE_LINK -> appendMarkdownLink(content, child)
-                MarkdownElementTypes.FULL_REFERENCE_LINK -> appendMarkdownLink(content, child)
-                TEXT -> append(child.getTextInNode(content).toString())
-                GFMTokenTypes.GFM_AUTOLINK -> if (child.parent == MarkdownElementTypes.LINK_TEXT) {
-                    append(child.getTextInNode(content).toString())
-                } else appendAutoLink(content, child)
+                    MarkdownElementTypes.AUTOLINK -> appendAutoLink(content, child)
+                    MarkdownElementTypes.INLINE_LINK -> appendMarkdownLink(content, child)
+                    MarkdownElementTypes.SHORT_REFERENCE_LINK -> appendMarkdownLink(content, child)
+                    MarkdownElementTypes.FULL_REFERENCE_LINK -> appendMarkdownLink(content, child)
+                    TEXT -> append(child.getTextInNode(content).toString())
+                    GFMTokenTypes.GFM_AUTOLINK -> if (child.parent == MarkdownElementTypes.LINK_TEXT) {
+                        append(child.getTextInNode(content).toString())
+                    } else appendAutoLink(content, child)
 
-                MarkdownTokenTypes.SINGLE_QUOTE -> append('\'')
-                MarkdownTokenTypes.DOUBLE_QUOTE -> append('\"')
-                MarkdownTokenTypes.LPAREN -> append('(')
-                MarkdownTokenTypes.RPAREN -> append(')')
-                MarkdownTokenTypes.LBRACKET -> append('[')
-                MarkdownTokenTypes.RBRACKET -> append(']')
-                MarkdownTokenTypes.LT -> append('<')
-                MarkdownTokenTypes.GT -> append('>')
-                MarkdownTokenTypes.COLON -> append(':')
-                MarkdownTokenTypes.EXCLAMATION_MARK -> append('!')
-                MarkdownTokenTypes.BACKTICK -> append('`')
-                MarkdownTokenTypes.HARD_LINE_BREAK -> append("\n\n")
-                MarkdownTokenTypes.EOL -> append('\n')
-                MarkdownTokenTypes.WHITE_SPACE -> if (length > 0) {
-                    append(' ')
-                }
+                    MarkdownTokenTypes.SINGLE_QUOTE -> append('\'')
+                    MarkdownTokenTypes.DOUBLE_QUOTE -> append('\"')
+                    MarkdownTokenTypes.LPAREN -> append('(')
+                    MarkdownTokenTypes.RPAREN -> append(')')
+                    MarkdownTokenTypes.LBRACKET -> append('[')
+                    MarkdownTokenTypes.RBRACKET -> append(']')
+                    MarkdownTokenTypes.LT -> append('<')
+                    MarkdownTokenTypes.GT -> append('>')
+                    MarkdownTokenTypes.COLON -> append(':')
+                    MarkdownTokenTypes.EXCLAMATION_MARK -> append('!')
+                    MarkdownTokenTypes.BACKTICK -> append('`')
+                    MarkdownTokenTypes.HARD_LINE_BREAK -> append("\n\n")
+                    MarkdownTokenTypes.EOL -> append('\n')
+                    MarkdownTokenTypes.WHITE_SPACE -> if (length > 0) {
+                        append(' ')
+                    }
 
-                MarkdownTokenTypes.BLOCK_QUOTE -> {
-                    skipIfNext = MarkdownTokenTypes.WHITE_SPACE
+                    MarkdownTokenTypes.BLOCK_QUOTE -> {
+                        skipIfNext = MarkdownTokenTypes.WHITE_SPACE
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
- introduce the new API to overwrite the annotation handling

```kotlin
Markdown(
    content,
    annotator = markdownAnnotator { content, child ->
        if (child.type == GFMElementTypes.STRIKETHROUGH) {
            append("Replaced you :)")
            true // return true to consume this ASTNode child
        } else false
    }
)
```