### PR TITLE
Fixed autolink showing and added examples

### DIFF
--- a/app-desktop/src/main/kotlin/main.kt
+++ b/app-desktop/src/main/kotlin/main.kt
@@ -134,4 +134,5 @@ Title 2
 [https://mikepenz.dev](https://mikepenz.dev)
 [https://github.com/mikepenz](https://github.com/mikepenz)
 [Mike Penz's Blog](https://blog.mikepenz.dev/)
+<https://blog.mikepenz.dev/>
 """

--- a/app-wasm/src/wasmJsMain/kotlin/Main.kt
+++ b/app-wasm/src/wasmJsMain/kotlin/Main.kt
@@ -161,4 +161,35 @@ This is an unordered list with asterisks:
 * Item 1
 * Item 2
 * Item 3
+
+-------- 
+
+# Random
+
+### Getting Started
+                
+For multiplatform projects specify this single dependency:
+
+```
+dependencies {
+    implementation("com.mikepenz:multiplatform-markdown-renderer:{version}")
+}
+```
+
+You can find more information on [GitHub](https://github.com/mikepenz/multiplatform-markdown-renderer). More Text after this.
+
+![Image](https://avatars.githubusercontent.com/u/1476232?v=4)
+
+There are many more things which can be experimented with like, inline `code`. 
+
+Title 1
+======
+
+Title 2
+------
+              
+[https://mikepenz.dev](https://mikepenz.dev)
+[https://github.com/mikepenz](https://github.com/mikepenz)
+[Mike Penz's Blog](https://blog.mikepenz.dev/)
+<https://blog.mikepenz.dev/>
 """

--- a/app/src/main/java/com/mikepenz/markdown/ui/MainActivity.kt
+++ b/app/src/main/java/com/mikepenz/markdown/ui/MainActivity.kt
@@ -179,4 +179,5 @@ Title 2
 [https://mikepenz.dev](https://mikepenz.dev)
 [https://github.com/mikepenz](https://github.com/mikepenz)
 [Mike Penz's Blog](https://blog.mikepenz.dev/)
+<https://blog.mikepenz.dev/>
 """

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
@@ -44,10 +44,19 @@ internal fun AnnotatedString.Builder.appendMarkdownLink(content: String, node: A
     pop()
 }
 
+@Composable
 internal fun AnnotatedString.Builder.appendAutoLink(content: String, node: ASTNode) {
-    val destination = node.getTextInNode(content).toString()
+    val targetNode =
+        node.children.firstOrNull { it.type.name == MarkdownElementTypes.AUTOLINK.name } ?: node
+    val destination = targetNode.getTextInNode(content).toString()
     pushStringAnnotation(TAG_URL, (destination))
-    pushStyle(SpanStyle(textDecoration = TextDecoration.Underline, fontWeight = FontWeight.Bold))
+    pushStyle(
+        SpanStyle(
+            color = LocalMarkdownColors.current.linkText,
+            textDecoration = TextDecoration.Underline,
+            fontWeight = FontWeight.Bold
+        )
+    )
     append(destination)
     pop()
 }


### PR DESCRIPTION
Hi Mike. I noticed a problem while working with urls like in the example below.  
``
<https://blog.mikepenz.dev/>
``  
[Markdown url syntax](https://www.markdownguide.org/basic-syntax/#urls-and-email-addresses)  
In the current solution, it shown with brackets. I made a fix for that.  
In Intellij's markdown parser it's called autolink. But for urls like in the markdown syntax, it has CompositeASTNode with 3 children.
One of them contains an autolink that does not equal MarkdownElementTypes.AUTOLINK due to it having the isToken property = true.
So, I implemented search of target element by element type name instead of getting all the text.  
Also, I noticed that such kind of links doesn't have underscores if i use ``SquigglyUnderlineSpanPainter``.  
I believe this happens because of unspecified color for span style while building the string for autolinks.  
Also, I added some autolink examples for test markdown strings in app, app-desktop and app-wasm.