### PR TITLE
Enhance list handling with different node types

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
@@ -12,13 +12,13 @@ import com.mikepenz.markdown.compose.components.MarkdownComponentModel
 import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.markdownComponents
 import com.mikepenz.markdown.model.ImageTransformer
-import com.mikepenz.markdown.model.NoOpImageTransformerImpl
 import com.mikepenz.markdown.model.MarkdownAnnotator
 import com.mikepenz.markdown.model.MarkdownColors
 import com.mikepenz.markdown.model.MarkdownDimens
 import com.mikepenz.markdown.model.MarkdownExtendedSpans
 import com.mikepenz.markdown.model.MarkdownPadding
 import com.mikepenz.markdown.model.MarkdownTypography
+import com.mikepenz.markdown.model.NoOpImageTransformerImpl
 import com.mikepenz.markdown.model.ReferenceLinkHandlerImpl
 import com.mikepenz.markdown.model.markdownAnnotator
 import com.mikepenz.markdown.model.markdownDimens
@@ -86,10 +86,11 @@ fun Markdown(
 }
 
 @Composable
-private fun ColumnScope.handleElement(
+internal fun ColumnScope.handleElement(
     node: ASTNode,
     components: MarkdownComponents,
-    content: String
+    content: String,
+    includeSpacer: Boolean = true,
 ): Boolean {
     val model = MarkdownComponentModel(
         content = content,
@@ -97,7 +98,7 @@ private fun ColumnScope.handleElement(
         typography = LocalMarkdownTypography.current
     )
     var handled = true
-    Spacer(Modifier.height(LocalMarkdownPadding.current.block))
+    if (includeSpacer) Spacer(Modifier.height(LocalMarkdownPadding.current.block))
     when (node.type) {
         TEXT -> components.text(this@handleElement, model)
         EOL -> components.eol(this@handleElement, model)
@@ -125,7 +126,7 @@ private fun ColumnScope.handleElement(
 
     if (!handled) {
         node.children.forEach { child ->
-            handleElement(child, components, content)
+            handleElement(child, components, content, includeSpacer)
         }
     }
 

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownList.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownList.kt
@@ -7,11 +7,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import com.mikepenz.markdown.compose.*
+import com.mikepenz.markdown.compose.LocalBulletListHandler
+import com.mikepenz.markdown.compose.LocalMarkdownColors
+import com.mikepenz.markdown.compose.LocalMarkdownPadding
+import com.mikepenz.markdown.compose.LocalMarkdownTypography
+import com.mikepenz.markdown.compose.LocalOrderedListHandler
+import com.mikepenz.markdown.compose.components.markdownComponents
 import com.mikepenz.markdown.compose.elements.material.MarkdownBasicText
-import com.mikepenz.markdown.utils.buildMarkdownAnnotatedString
-import com.mikepenz.markdown.utils.filterNonListTypes
+import com.mikepenz.markdown.compose.handleElement
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownElementTypes.ORDERED_LIST
 import org.intellij.markdown.MarkdownElementTypes.UNORDERED_LIST
@@ -31,7 +34,13 @@ fun MarkdownListItems(
 ) {
     val listDp = LocalMarkdownPadding.current.list
     val indentListDp = LocalMarkdownPadding.current.indentList
-    Column(modifier = Modifier.padding(start = (indentListDp) * level, top = listDp, bottom = listDp)) {
+    Column(
+        modifier = Modifier.padding(
+            start = (indentListDp) * level,
+            top = listDp,
+            bottom = listDp
+        )
+    ) {
         var index = 0
         node.children.forEach { child ->
             when (child.type) {
@@ -41,16 +50,6 @@ fun MarkdownListItems(
                         ORDERED_LIST -> MarkdownOrderedList(content, child, style, level + 1)
                         UNORDERED_LIST -> MarkdownBulletList(content, child, style, level + 1)
                     }
-                    index++
-                }
-
-                ORDERED_LIST -> {
-                    MarkdownOrderedList(content, child, style, level + 1)
-                    index++
-                }
-
-                UNORDERED_LIST -> {
-                    MarkdownBulletList(content, child, style, level + 1)
                     index++
                 }
             }
@@ -70,16 +69,23 @@ fun MarkdownOrderedList(
     MarkdownListItems(content, node, style, level) { index, child ->
         Row(Modifier.fillMaxWidth()) {
             MarkdownBasicText(
-                text = orderedListHandler.transform(LIST_NUMBER, child.findChildOfType(LIST_NUMBER)?.getTextInNode(content), index),
+                text = orderedListHandler.transform(
+                    LIST_NUMBER,
+                    child.findChildOfType(LIST_NUMBER)?.getTextInNode(content),
+                    index
+                ),
                 style = style,
                 color = LocalMarkdownColors.current.text
             )
-            val text = buildAnnotatedString {
-                pushStyle(style.toSpanStyle())
-                buildMarkdownAnnotatedString(content, child.children.filterNonListTypes())
-                pop()
+
+            Column(Modifier.padding(bottom = listItemBottom)) {
+                handleElement(
+                    node = child,
+                    components = markdownComponents(),
+                    content = content,
+                    includeSpacer = false
+                )
             }
-            MarkdownText(text, Modifier.padding(bottom = listItemBottom), style = style)
         }
     }
 }
@@ -96,16 +102,23 @@ fun MarkdownBulletList(
     MarkdownListItems(content, node, style, level) { index, child ->
         Row(Modifier.fillMaxWidth()) {
             MarkdownBasicText(
-                bulletHandler.transform(LIST_BULLET, child.findChildOfType(LIST_BULLET)?.getTextInNode(content), index),
+                bulletHandler.transform(
+                    LIST_BULLET,
+                    child.findChildOfType(LIST_BULLET)?.getTextInNode(content),
+                    index
+                ),
                 style = style,
                 color = LocalMarkdownColors.current.text
             )
-            val text = buildAnnotatedString {
-                pushStyle(style.toSpanStyle())
-                buildMarkdownAnnotatedString(content, child.children.filterNonListTypes())
-                pop()
+
+            Column(Modifier.padding(bottom = listItemBottom)) {
+                handleElement(
+                    node = child,
+                    components = markdownComponents(),
+                    content = content,
+                    includeSpacer = false
+                )
             }
-            MarkdownText(text, Modifier.padding(bottom = listItemBottom), style = style)
         }
     }
 }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
@@ -1,8 +1,6 @@
 package com.mikepenz.markdown.utils
 
 import org.intellij.markdown.IElementType
-import org.intellij.markdown.MarkdownElementTypes
-import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
 
 /**
@@ -37,10 +35,3 @@ internal fun ASTNode.findChildOfTypeRecursive(type: IElementType): ASTNode? {
  * E.g. we don't want to render the brackets of a link
  */
 internal fun List<ASTNode>.innerList(): List<ASTNode> = this.subList(1, this.size - 1)
-
-/**
- * Helper function to filter out items within a list of nodes, not of interest for the bullet list.
- */
-internal fun List<ASTNode>.filterNonListTypes(): List<ASTNode> = this.filter { n ->
-    n.type != MarkdownElementTypes.ORDERED_LIST && n.type != MarkdownElementTypes.UNORDERED_LIST && n.type != MarkdownTokenTypes.EOL
-}


### PR DESCRIPTION
- enhance type support of lists by enabling full node handling including code blocks
  - FIX #167

The specific sample will be rendered as: 

<img width="587" alt="Screenshot 2024-06-20 at 14 28 37" src="https://github.com/mikepenz/multiplatform-markdown-renderer/assets/1476232/334586b3-e652-4aa5-a395-2cb056aa0aff">
