### PR TITLE
Ensure custom `MarkdownComponents` are also available to `Lists`

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/ComposeLocal.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/ComposeLocal.kt
@@ -2,6 +2,8 @@ package com.mikepenz.markdown.compose
 
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
+import com.mikepenz.markdown.compose.components.MarkdownComponents
+import com.mikepenz.markdown.compose.components.markdownComponents
 import com.mikepenz.markdown.model.BulletHandler
 import com.mikepenz.markdown.model.DefaultMarkdownAnnotator
 import com.mikepenz.markdown.model.DefaultMarkdownExtendedSpans
@@ -82,4 +84,11 @@ val LocalMarkdownAnnotator = compositionLocalOf<MarkdownAnnotator> {
  */
 val LocalMarkdownExtendedSpans = compositionLocalOf<MarkdownExtendedSpans> {
     return@compositionLocalOf DefaultMarkdownExtendedSpans(null)
+}
+
+/**
+ * Local [MarkdownComponents] provider
+ */
+val LocalMarkdownComponents = compositionLocalOf<MarkdownComponents> {
+    return@compositionLocalOf markdownComponents()
 }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
@@ -1,29 +1,13 @@
 package com.mikepenz.markdown.compose
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import com.mikepenz.markdown.compose.components.MarkdownComponentModel
 import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.markdownComponents
-import com.mikepenz.markdown.model.ImageTransformer
-import com.mikepenz.markdown.model.MarkdownAnnotator
-import com.mikepenz.markdown.model.MarkdownColors
-import com.mikepenz.markdown.model.MarkdownDimens
-import com.mikepenz.markdown.model.MarkdownExtendedSpans
-import com.mikepenz.markdown.model.MarkdownPadding
-import com.mikepenz.markdown.model.MarkdownTypography
-import com.mikepenz.markdown.model.NoOpImageTransformerImpl
-import com.mikepenz.markdown.model.ReferenceLinkHandlerImpl
-import com.mikepenz.markdown.model.markdownAnnotator
-import com.mikepenz.markdown.model.markdownDimens
-import com.mikepenz.markdown.model.markdownExtendedSpans
-import com.mikepenz.markdown.model.markdownPadding
+import com.mikepenz.markdown.model.*
 import org.intellij.markdown.MarkdownElementTypes.ATX_1
 import org.intellij.markdown.MarkdownElementTypes.ATX_2
 import org.intellij.markdown.MarkdownElementTypes.ATX_3
@@ -70,7 +54,8 @@ fun Markdown(
         LocalMarkdownTypography provides typography,
         LocalImageTransformer provides imageTransformer,
         LocalMarkdownAnnotator provides annotator,
-        LocalMarkdownExtendedSpans provides extendedSpans
+        LocalMarkdownExtendedSpans provides extendedSpans,
+        LocalMarkdownComponents provides components,
     ) {
         Column(modifier) {
             val parsedTree = MarkdownParser(flavour).buildMarkdownTreeFromString(content)

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/components/MarkdownComponents.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/components/MarkdownComponents.kt
@@ -31,7 +31,6 @@ data class MarkdownComponentModel(
 
 private fun MarkdownComponentModel.getTextInNode() = node.getTextInNode(content)
 
-@Composable
 fun markdownComponents(
     text: MarkdownComponent = CurrentComponentsBridge.text,
     eol: MarkdownComponent = CurrentComponentsBridge.eol,

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownList.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownList.kt
@@ -7,14 +7,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
-import com.mikepenz.markdown.compose.LocalBulletListHandler
-import com.mikepenz.markdown.compose.LocalMarkdownColors
-import com.mikepenz.markdown.compose.LocalMarkdownPadding
-import com.mikepenz.markdown.compose.LocalMarkdownTypography
-import com.mikepenz.markdown.compose.LocalOrderedListHandler
-import com.mikepenz.markdown.compose.components.markdownComponents
+import com.mikepenz.markdown.compose.*
 import com.mikepenz.markdown.compose.elements.material.MarkdownBasicText
-import com.mikepenz.markdown.compose.handleElement
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownElementTypes.ORDERED_LIST
 import org.intellij.markdown.MarkdownElementTypes.UNORDERED_LIST
@@ -30,7 +24,7 @@ fun MarkdownListItems(
     node: ASTNode,
     style: TextStyle = LocalMarkdownTypography.current.list,
     level: Int = 0,
-    item: @Composable (index: Int, child: ASTNode) -> Unit
+    item: @Composable (index: Int, child: ASTNode) -> Unit,
 ) {
     val listDp = LocalMarkdownPadding.current.list
     val indentListDp = LocalMarkdownPadding.current.indentList
@@ -62,7 +56,7 @@ fun MarkdownOrderedList(
     content: String,
     node: ASTNode,
     style: TextStyle = LocalMarkdownTypography.current.ordered,
-    level: Int = 0
+    level: Int = 0,
 ) {
     val orderedListHandler = LocalOrderedListHandler.current
     val listItemBottom = LocalMarkdownPadding.current.listItemBottom
@@ -81,7 +75,7 @@ fun MarkdownOrderedList(
             Column(Modifier.padding(bottom = listItemBottom)) {
                 handleElement(
                     node = child,
-                    components = markdownComponents(),
+                    components = LocalMarkdownComponents.current,
                     content = content,
                     includeSpacer = false
                 )
@@ -95,7 +89,7 @@ fun MarkdownBulletList(
     content: String,
     node: ASTNode,
     style: TextStyle = LocalMarkdownTypography.current.bullet,
-    level: Int = 0
+    level: Int = 0,
 ) {
     val bulletHandler = LocalBulletListHandler.current
     val listItemBottom = LocalMarkdownPadding.current.listItemBottom
@@ -114,7 +108,7 @@ fun MarkdownBulletList(
             Column(Modifier.padding(bottom = listItemBottom)) {
                 handleElement(
                     node = child,
-                    components = markdownComponents(),
+                    components = LocalMarkdownComponents.current,
                     content = content,
                     includeSpacer = false
                 )


### PR DESCRIPTION
- add new feature to use the same custom markdown components in a bullet list via a `LocalMarkdownComponents` provider
  - FIX https://github.com/mikepenz/multiplatform-markdown-renderer/issues/184