### PR TITLE
Making use of EntityConverter to unescape text of leaf nodes

### DIFF
--- a/app/src/screenshotTest/kotlin/com.mikepenz.markdown.ui/SnapshotTests.kt
+++ b/app/src/screenshotTest/kotlin/com.mikepenz.markdown.ui/SnapshotTests.kt
@@ -63,11 +63,11 @@ private val MARKDOWN_DEFAULT = """
 
 ###### This is an H6
 
-This is a paragraph with some *italic* and **bold** text.
+This is a paragraph with some *italic* and **bold** text\.
 
-This is a paragraph with some `inline code`.
+This is a paragraph with some `inline code`\.
 
-This is a paragraph with a [link](https://www.jetbrains.com/).
+This is a paragraph with a [link](https://www.jetbrains.com/)\.
 
 This is a code block:
 ```kotlin

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/components/MarkdownComponents.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/components/MarkdownComponents.kt
@@ -9,12 +9,12 @@ import androidx.compose.ui.Modifier
 import com.mikepenz.markdown.compose.LocalReferenceLinkHandler
 import com.mikepenz.markdown.compose.elements.*
 import com.mikepenz.markdown.model.MarkdownTypography
+import com.mikepenz.markdown.utils.getUnescapedTextInNode
 import org.intellij.markdown.IElementType
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.findChildOfType
-import org.intellij.markdown.ast.getTextInNode
 
 typealias MarkdownComponent = @Composable ColumnScope.(MarkdownComponentModel) -> Unit
 
@@ -29,7 +29,7 @@ data class MarkdownComponentModel(
     val typography: MarkdownTypography,
 )
 
-private fun MarkdownComponentModel.getTextInNode() = node.getTextInNode(content)
+private fun MarkdownComponentModel.getUnescapedTextInNode() = node.getUnescapedTextInNode(content)
 
 fun markdownComponents(
     text: MarkdownComponent = CurrentComponentsBridge.text,
@@ -130,7 +130,7 @@ private class DefaultMarkdownComponents(
  */
 object CurrentComponentsBridge {
     val text: MarkdownComponent = {
-        MarkdownText(it.getTextInNode().toString())
+        MarkdownText(it.getUnescapedTextInNode())
     }
     val eol: MarkdownComponent = { }
     val codeFence: MarkdownComponent = {
@@ -184,11 +184,10 @@ object CurrentComponentsBridge {
     }
     val linkDefinition: MarkdownComponent = {
         val linkLabel =
-            it.node.findChildOfType(MarkdownElementTypes.LINK_LABEL)?.getTextInNode(it.content)
-                ?.toString()
+            it.node.findChildOfType(MarkdownElementTypes.LINK_LABEL)?.getUnescapedTextInNode(it.content)
         if (linkLabel != null) {
             val destination = it.node.findChildOfType(MarkdownElementTypes.LINK_DESTINATION)
-                ?.getTextInNode(it.content)?.toString()
+                ?.getUnescapedTextInNode(it.content)
             LocalReferenceLinkHandler.current.store(linkLabel, destination)
         }
     }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownImage.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownImage.kt
@@ -4,14 +4,14 @@ import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
 import com.mikepenz.markdown.compose.LocalImageTransformer
 import com.mikepenz.markdown.utils.findChildOfTypeRecursive
+import com.mikepenz.markdown.utils.getUnescapedTextInNode
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.ast.ASTNode
-import org.intellij.markdown.ast.getTextInNode
 
 @Composable
 fun MarkdownImage(content: String, node: ASTNode) {
 
-    val link = node.findChildOfTypeRecursive(MarkdownElementTypes.LINK_DESTINATION)?.getTextInNode(content)?.toString() ?: return
+    val link = node.findChildOfTypeRecursive(MarkdownElementTypes.LINK_DESTINATION)?.getUnescapedTextInNode(content) ?: return
 
     LocalImageTransformer.current.transform(link)?.let { imageData ->
         Image(

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownList.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownList.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import com.mikepenz.markdown.compose.*
 import com.mikepenz.markdown.compose.elements.material.MarkdownBasicText
+import com.mikepenz.markdown.utils.getUnescapedTextInNode
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownElementTypes.ORDERED_LIST
 import org.intellij.markdown.MarkdownElementTypes.UNORDERED_LIST
@@ -16,7 +17,6 @@ import org.intellij.markdown.MarkdownTokenTypes.Companion.LIST_BULLET
 import org.intellij.markdown.MarkdownTokenTypes.Companion.LIST_NUMBER
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.findChildOfType
-import org.intellij.markdown.ast.getTextInNode
 
 @Composable
 fun MarkdownListItems(
@@ -65,7 +65,7 @@ fun MarkdownOrderedList(
             MarkdownBasicText(
                 text = orderedListHandler.transform(
                     LIST_NUMBER,
-                    child.findChildOfType(LIST_NUMBER)?.getTextInNode(content),
+                    child.findChildOfType(LIST_NUMBER)?.getUnescapedTextInNode(content),
                     index
                 ),
                 style = style,
@@ -98,7 +98,7 @@ fun MarkdownBulletList(
             MarkdownBasicText(
                 bulletHandler.transform(
                     LIST_BULLET,
-                    child.findChildOfType(LIST_BULLET)?.getTextInNode(content),
+                    child.findChildOfType(LIST_BULLET)?.getUnescapedTextInNode(content),
                     index
                 ),
                 style = style,

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
@@ -14,7 +14,6 @@ import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.findChildOfType
-import org.intellij.markdown.ast.getTextInNode
 import org.intellij.markdown.flavours.gfm.GFMElementTypes
 import org.intellij.markdown.flavours.gfm.GFMTokenTypes
 
@@ -22,14 +21,14 @@ import org.intellij.markdown.flavours.gfm.GFMTokenTypes
 internal fun AnnotatedString.Builder.appendMarkdownLink(content: String, node: ASTNode) {
     val linkText = node.findChildOfType(MarkdownElementTypes.LINK_TEXT)?.children?.innerList()
     if (linkText == null) {
-        append(node.getTextInNode(content).toString())
+        append(node.getUnescapedTextInNode(content))
         return
     }
     val destination = node.findChildOfType(MarkdownElementTypes.LINK_DESTINATION)
-        ?.getTextInNode(content)
+        ?.getUnescapedTextInNode(content)
         ?.toString()
     val linkLabel = node.findChildOfType(MarkdownElementTypes.LINK_LABEL)
-        ?.getTextInNode(content)?.toString()
+        ?.getUnescapedTextInNode(content)
     val annotation = destination ?: linkLabel
     if (annotation != null) pushStringAnnotation(MARKDOWN_TAG_URL, annotation)
     pushStyle(
@@ -49,7 +48,7 @@ internal fun AnnotatedString.Builder.appendAutoLink(content: String, node: ASTNo
     val targetNode = node.children.firstOrNull {
         it.type.name == MarkdownElementTypes.AUTOLINK.name
     } ?: node
-    val destination = targetNode.getTextInNode(content).toString()
+    val destination = targetNode.getUnescapedTextInNode(content)
     pushStringAnnotation(MARKDOWN_TAG_URL, (destination))
     pushStyle(
         SpanStyle(
@@ -100,7 +99,7 @@ fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, childr
                     MarkdownElementTypes.IMAGE -> child.findChildOfTypeRecursive(
                         MarkdownElementTypes.LINK_DESTINATION
                     )?.let {
-                        appendInlineContent(MARKDOWN_TAG_IMAGE_URL, it.getTextInNode(content).toString())
+                        appendInlineContent(MARKDOWN_TAG_IMAGE_URL, it.getUnescapedTextInNode(content))
                     }
 
                     MarkdownElementTypes.EMPH -> {
@@ -141,9 +140,9 @@ fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, childr
                     MarkdownElementTypes.FULL_REFERENCE_LINK -> appendMarkdownLink(content, child)
 
                     // Token Types
-                    MarkdownTokenTypes.TEXT -> append(child.getTextInNode(content).toString())
+                    MarkdownTokenTypes.TEXT -> append(child.getUnescapedTextInNode(content))
                     GFMTokenTypes.GFM_AUTOLINK -> if (child.parent == MarkdownElementTypes.LINK_TEXT) {
-                        append(child.getTextInNode(content).toString())
+                        append(child.getUnescapedTextInNode(content))
                     } else appendAutoLink(content, child)
 
                     MarkdownTokenTypes.SINGLE_QUOTE -> append('\'')

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
@@ -2,6 +2,8 @@ package com.mikepenz.markdown.utils
 
 import org.intellij.markdown.IElementType
 import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.ast.getTextInNode
+import org.intellij.markdown.html.entities.EntityConverter
 
 /**
  * Tag used to indicate an url for inline content. Required for click handling.
@@ -35,3 +37,8 @@ internal fun ASTNode.findChildOfTypeRecursive(type: IElementType): ASTNode? {
  * E.g. we don't want to render the brackets of a link
  */
 internal fun List<ASTNode>.innerList(): List<ASTNode> = this.subList(1, this.size - 1)
+
+internal fun ASTNode.getUnescapedTextInNode(allFileText: CharSequence): String {
+    val escapedText = getTextInNode(allFileText).toString()
+    return EntityConverter.replaceEntities(escapedText, false, true)
+}


### PR DESCRIPTION
Currently leaf node text is not unescaped, even though it should be. For example the Markdown text `1\.` is incorrectly rendered with a backslash. The `HTMLGenerator` from the Intellij Markdown library is a good example where it is using `EntityConverter` to unescape this text. This PR adds unescaping using the same `EntityConverter` class.