### PR TITLE
Make links in text stylable via the MarkdownTypography class

### DIFF
--- a/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/MarkdownTypography.kt
+++ b/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/MarkdownTypography.kt
@@ -6,6 +6,9 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import com.mikepenz.markdown.compose.LocalMarkdownColors
 import com.mikepenz.markdown.model.DefaultMarkdownTypography
 import com.mikepenz.markdown.model.MarkdownTypography
 
@@ -23,9 +26,14 @@ fun markdownTypography(
     paragraph: TextStyle = MaterialTheme.typography.body1,
     ordered: TextStyle = MaterialTheme.typography.body1,
     bullet: TextStyle = MaterialTheme.typography.body1,
-    list: TextStyle = MaterialTheme.typography.body1
+    list: TextStyle = MaterialTheme.typography.body1,
+    link: TextStyle = MaterialTheme.typography.body1.copy(
+        fontWeight = FontWeight.Bold,
+        color = markdownColor().linkText,
+        textDecoration = TextDecoration.Underline
+    ),
 ): MarkdownTypography = DefaultMarkdownTypography(
     h1 = h1, h2 = h2, h3 = h3, h4 = h4, h5 = h5, h6 = h6,
     text = text, quote = quote, code = code, paragraph = paragraph,
-    ordered = ordered, bullet = bullet, list = list
+    ordered = ordered, bullet = bullet, list = list, link = link,
 )

--- a/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/MarkdownTypography.kt
+++ b/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/MarkdownTypography.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
-import com.mikepenz.markdown.compose.LocalMarkdownColors
 import com.mikepenz.markdown.model.DefaultMarkdownTypography
 import com.mikepenz.markdown.model.MarkdownTypography
 

--- a/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/MarkdownTypography.kt
+++ b/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/MarkdownTypography.kt
@@ -29,7 +29,6 @@ fun markdownTypography(
     list: TextStyle = MaterialTheme.typography.body1,
     link: TextStyle = MaterialTheme.typography.body1.copy(
         fontWeight = FontWeight.Bold,
-        color = markdownColor().linkText,
         textDecoration = TextDecoration.Underline
     ),
 ): MarkdownTypography = DefaultMarkdownTypography(

--- a/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/MarkdownTypography.kt
+++ b/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/MarkdownTypography.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
-import com.mikepenz.markdown.compose.LocalMarkdownColors
 import com.mikepenz.markdown.model.DefaultMarkdownTypography
 import com.mikepenz.markdown.model.MarkdownTypography
 

--- a/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/MarkdownTypography.kt
+++ b/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/MarkdownTypography.kt
@@ -6,6 +6,9 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import com.mikepenz.markdown.compose.LocalMarkdownColors
 import com.mikepenz.markdown.model.DefaultMarkdownTypography
 import com.mikepenz.markdown.model.MarkdownTypography
 
@@ -23,9 +26,14 @@ fun markdownTypography(
     paragraph: TextStyle = MaterialTheme.typography.bodyLarge,
     ordered: TextStyle = MaterialTheme.typography.bodyLarge,
     bullet: TextStyle = MaterialTheme.typography.bodyLarge,
-    list: TextStyle = MaterialTheme.typography.bodyLarge
+    list: TextStyle = MaterialTheme.typography.bodyLarge,
+    link: TextStyle = MaterialTheme.typography.bodyLarge.copy(
+        fontWeight = FontWeight.Bold,
+        color = markdownColor().linkText,
+        textDecoration = TextDecoration.Underline
+    ),
 ): MarkdownTypography = DefaultMarkdownTypography(
     h1 = h1, h2 = h2, h3 = h3, h4 = h4, h5 = h5, h6 = h6,
     text = text, quote = quote, code = code, paragraph = paragraph,
-    ordered = ordered, bullet = bullet, list = list
+    ordered = ordered, bullet = bullet, list = list, link = link,
 )

--- a/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/MarkdownTypography.kt
+++ b/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/MarkdownTypography.kt
@@ -29,7 +29,6 @@ fun markdownTypography(
     list: TextStyle = MaterialTheme.typography.bodyLarge,
     link: TextStyle = MaterialTheme.typography.bodyLarge.copy(
         fontWeight = FontWeight.Bold,
-        color = markdownColor().linkText,
         textDecoration = TextDecoration.Underline
     ),
 ): MarkdownTypography = DefaultMarkdownTypography(

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownTypography.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownTypography.kt
@@ -1,7 +1,6 @@
 package com.mikepenz.markdown.model
 
 import androidx.compose.runtime.Immutable
-import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 
 interface MarkdownTypography {

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownTypography.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownTypography.kt
@@ -1,6 +1,7 @@
 package com.mikepenz.markdown.model
 
 import androidx.compose.runtime.Immutable
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 
 interface MarkdownTypography {
@@ -17,6 +18,7 @@ interface MarkdownTypography {
     val ordered: TextStyle
     val bullet: TextStyle
     val list: TextStyle
+    val link: TextStyle
 }
 
 @Immutable
@@ -33,5 +35,6 @@ class DefaultMarkdownTypography(
     override val paragraph: TextStyle,
     override val ordered: TextStyle,
     override val bullet: TextStyle,
-    override val list: TextStyle
+    override val list: TextStyle,
+    override val link: TextStyle,
 ) : MarkdownTypography

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
@@ -33,9 +33,9 @@ internal fun AnnotatedString.Builder.appendMarkdownLink(content: String, node: A
         ?.getTextInNode(content)?.toString()
     val annotation = destination ?: linkLabel
     if (annotation != null) pushStringAnnotation(MARKDOWN_TAG_URL, annotation)
-    pushStyle(
-        LocalMarkdownTypography.current.link.toSpanStyle()
-    )
+    val linkColor = LocalMarkdownColors.current.linkText
+    val linkTextStyle = LocalMarkdownTypography.current.link.copy(color = linkColor).toSpanStyle()
+    pushStyle(linkTextStyle)
     buildMarkdownAnnotatedString(content, linkText)
     pop()
     if (annotation != null) pop()
@@ -48,10 +48,9 @@ internal fun AnnotatedString.Builder.appendAutoLink(content: String, node: ASTNo
     } ?: node
     val destination = targetNode.getTextInNode(content).toString()
     pushStringAnnotation(MARKDOWN_TAG_URL, (destination))
-    LocalMarkdownTypography.current.link.toSpanStyle()
-    pushStyle(
-        LocalMarkdownTypography.current.link.toSpanStyle()
-    )
+    val linkColor = LocalMarkdownColors.current.linkText
+    val linkTextStyle = LocalMarkdownTypography.current.link.copy(color = linkColor).toSpanStyle()
+    pushStyle(linkTextStyle)
     append(destination)
     pop()
 }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import com.mikepenz.markdown.compose.LocalMarkdownAnnotator
 import com.mikepenz.markdown.compose.LocalMarkdownColors
+import com.mikepenz.markdown.compose.LocalMarkdownTypography
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
@@ -33,11 +34,7 @@ internal fun AnnotatedString.Builder.appendMarkdownLink(content: String, node: A
     val annotation = destination ?: linkLabel
     if (annotation != null) pushStringAnnotation(MARKDOWN_TAG_URL, annotation)
     pushStyle(
-        SpanStyle(
-            color = LocalMarkdownColors.current.linkText,
-            textDecoration = TextDecoration.Underline,
-            fontWeight = FontWeight.Bold
-        )
+        LocalMarkdownTypography.current.link.toSpanStyle()
     )
     buildMarkdownAnnotatedString(content, linkText)
     pop()
@@ -51,12 +48,9 @@ internal fun AnnotatedString.Builder.appendAutoLink(content: String, node: ASTNo
     } ?: node
     val destination = targetNode.getTextInNode(content).toString()
     pushStringAnnotation(MARKDOWN_TAG_URL, (destination))
+    LocalMarkdownTypography.current.link.toSpanStyle()
     pushStyle(
-        SpanStyle(
-            color = LocalMarkdownColors.current.linkText,
-            textDecoration = TextDecoration.Underline,
-            fontWeight = FontWeight.Bold
-        )
+        LocalMarkdownTypography.current.link.toSpanStyle()
     )
     append(destination)
     pop()


### PR DESCRIPTION
make link text spanStyle configurable via the `MarkdownTypography` class this allows use to change it if they want change the fontWeight or text decoration.