### PR TITLE
Introduce new API to build annotated markdown strings to be used in standard `Text` composables

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHeader.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHeader.kt
@@ -3,7 +3,11 @@ package com.mikepenz.markdown.compose.elements
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import com.mikepenz.markdown.compose.LocalMarkdownAnnotator
+import com.mikepenz.markdown.compose.LocalMarkdownTypography
 import com.mikepenz.markdown.utils.buildMarkdownAnnotatedString
+import com.mikepenz.markdown.utils.codeSpanStyle
+import com.mikepenz.markdown.utils.linkTextSpanStyle
 import org.intellij.markdown.IElementType
 import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
@@ -16,11 +20,14 @@ fun MarkdownHeader(
     style: TextStyle,
     contentChildType: IElementType = MarkdownTokenTypes.ATX_CONTENT,
 ) {
+    val annotator = LocalMarkdownAnnotator.current
+    val linkTextSpanStyle = LocalMarkdownTypography.current.linkTextSpanStyle
+    val codeSpanStyle = LocalMarkdownTypography.current.codeSpanStyle
 
     node.findChildOfType(contentChildType)?.let {
         val styledText = buildAnnotatedString {
             pushStyle(style.toSpanStyle())
-            buildMarkdownAnnotatedString(content, it)
+            buildMarkdownAnnotatedString(content, it, linkTextSpanStyle, codeSpanStyle, annotator)
             pop()
         }
 

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownParagraph.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownParagraph.kt
@@ -4,8 +4,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import com.mikepenz.markdown.compose.LocalMarkdownAnnotator
 import com.mikepenz.markdown.compose.LocalMarkdownTypography
 import com.mikepenz.markdown.utils.buildMarkdownAnnotatedString
+import com.mikepenz.markdown.utils.codeSpanStyle
+import com.mikepenz.markdown.utils.linkTextSpanStyle
 import org.intellij.markdown.ast.ASTNode
 
 @Composable
@@ -15,9 +18,12 @@ fun MarkdownParagraph(
     modifier: Modifier = Modifier,
     style: TextStyle = LocalMarkdownTypography.current.paragraph,
 ) {
+    val annotator = LocalMarkdownAnnotator.current
+    val linkTextSpanStyle = LocalMarkdownTypography.current.linkTextSpanStyle
+    val codeSpanStyle = LocalMarkdownTypography.current.codeSpanStyle
     val styledText = buildAnnotatedString {
         pushStyle(style.toSpanStyle())
-        buildMarkdownAnnotatedString(content, node)
+        buildMarkdownAnnotatedString(content, node, linkTextSpanStyle, codeSpanStyle, annotator)
         pop()
     }
 

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
@@ -41,7 +41,7 @@ fun MarkdownText(
     style: TextStyle = LocalMarkdownTypography.current.text,
     extendedSpans: ExtendedSpans? = LocalMarkdownExtendedSpans.current.extendedSpans?.invoke(),
 ) {
-    // extend the annotated string with extended spans styles if provided
+    // extend the annotated string with `extended-spans` styles if provided
     val extendedStyledText = if (extendedSpans != null) {
         remember(content) {
             extendedSpans.extend(content)
@@ -59,7 +59,7 @@ fun MarkdownText(
         {}
     }
 
-    // call drawBehind with the `exended-spans` if provided
+    // call drawBehind with the `extended-spans` if provided
     val extendedModifier = if (extendedSpans != null) {
         modifier.drawBehind(extendedSpans)
     } else modifier

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/AnnotatedStringKtx.kt
@@ -4,55 +4,166 @@ import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import com.mikepenz.markdown.compose.LocalMarkdownAnnotator
-import com.mikepenz.markdown.compose.LocalMarkdownColors
 import com.mikepenz.markdown.compose.LocalMarkdownTypography
+import com.mikepenz.markdown.model.MarkdownAnnotator
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.findChildOfType
+import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMElementTypes
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMTokenTypes
+import org.intellij.markdown.parser.MarkdownParser
 
+/**
+ * Extension function to build an `AnnotatedString` from a Markdown string.
+ * This function will parse the Markdown content and apply the given styles to the text.
+ *
+ * It only supports TEXT and PARAGRAPH nodes.
+ *
+ * @param style The base text style to apply.
+ * @param linkTextSpanStyle The style to apply to link text.
+ * @param codeSpanStyle The style to apply to code spans.
+ * @param flavour The Markdown flavour descriptor to use (default is GFM).
+ * @param annotator An optional annotator for additional processing.
+ * @return The constructed `AnnotatedString`.
+ */
+fun String.buildMarkdownAnnotatedString(
+    style: TextStyle,
+    linkTextSpanStyle: SpanStyle = style.toSpanStyle(),
+    codeSpanStyle: SpanStyle = style.toSpanStyle(),
+    flavour: MarkdownFlavourDescriptor = GFMFlavourDescriptor(),
+    annotator: MarkdownAnnotator? = null,
+): AnnotatedString {
+    val content = this
+    val parsedTree = MarkdownParser(flavour).buildMarkdownTreeFromString(content)
+    val textNode = parsedTree.children.firstOrNull { node ->
+        node.type == MarkdownTokenTypes.TEXT || node.type == MarkdownElementTypes.PARAGRAPH
+    }
+    if (textNode == null) return buildAnnotatedString { }
+    return content.buildMarkdownAnnotatedString(
+        textNode = textNode,
+        style = style,
+        linkTextSpanStyle = linkTextSpanStyle,
+        codeSpanStyle = codeSpanStyle,
+        annotator = annotator
+    )
+}
+
+/**
+ * Extension function to build an `AnnotatedString` from a Markdown string.
+ * This function will parse the Markdown content and apply the given styles to the text.
+ *
+ * It only supports TEXT and PARAGRAPH nodes.
+ *
+ * @param textNode The AST node representing the text.
+ * @param style The base text style to apply.
+ * @param linkTextSpanStyle The style to apply to link text.
+ * @param codeSpanStyle The style to apply to code spans.
+ * @param annotator An optional annotator for additional processing.
+ * @return The constructed `AnnotatedString`.
+ */
+fun String.buildMarkdownAnnotatedString(
+    textNode: ASTNode,
+    style: TextStyle,
+    linkTextSpanStyle: SpanStyle = style.toSpanStyle(),
+    codeSpanStyle: SpanStyle = style.toSpanStyle(),
+    annotator: MarkdownAnnotator? = null,
+): AnnotatedString = buildAnnotatedString {
+    pushStyle(style.toSpanStyle())
+    buildMarkdownAnnotatedString(this@buildMarkdownAnnotatedString, textNode, linkTextSpanStyle, codeSpanStyle, annotator)
+    pop()
+}
+
+@Deprecated("Use the non composable `appendMarkdownLink` function instead. This function will be removed in a future release.")
 @Composable
-internal fun AnnotatedString.Builder.appendMarkdownLink(content: String, node: ASTNode) {
+fun AnnotatedString.Builder.appendMarkdownLink(content: String, node: ASTNode) = appendMarkdownLink(
+    content = content,
+    node = node,
+    linkTextStyle = LocalMarkdownTypography.current.linkTextSpanStyle,
+    codeStyle = LocalMarkdownTypography.current.codeSpanStyle,
+    annotator = LocalMarkdownAnnotator.current
+)
+
+/**
+ * Appends a Markdown link to the `AnnotatedString.Builder`.
+ *
+ * @param content The content string.
+ * @param node The AST node representing the link.
+ * @param linkTextStyle The style to apply to the link text.
+ * @param codeStyle The style to apply to code spans within the link.
+ * @param annotator An optional annotator for additional processing.
+ */
+fun AnnotatedString.Builder.appendMarkdownLink(
+    content: String,
+    node: ASTNode,
+    linkTextStyle: SpanStyle,
+    codeStyle: SpanStyle,
+    annotator: MarkdownAnnotator? = null,
+) {
     val linkText = node.findChildOfType(MarkdownElementTypes.LINK_TEXT)?.children?.innerList()
     if (linkText == null) {
         append(node.getUnescapedTextInNode(content))
         return
     }
-    val destination = node.findChildOfType(MarkdownElementTypes.LINK_DESTINATION)
-        ?.getUnescapedTextInNode(content)
-        ?.toString()
-    val linkLabel = node.findChildOfType(MarkdownElementTypes.LINK_LABEL)
-        ?.getUnescapedTextInNode(content)
+    val destination = node.findChildOfType(MarkdownElementTypes.LINK_DESTINATION)?.getUnescapedTextInNode(content)
+    val linkLabel = node.findChildOfType(MarkdownElementTypes.LINK_LABEL)?.getUnescapedTextInNode(content)
     val annotation = destination ?: linkLabel
     if (annotation != null) pushStringAnnotation(MARKDOWN_TAG_URL, annotation)
-    val linkColor = LocalMarkdownColors.current.linkText
-    val linkTextStyle = LocalMarkdownTypography.current.link.copy(color = linkColor).toSpanStyle()
     pushStyle(linkTextStyle)
-    buildMarkdownAnnotatedString(content, linkText)
+    buildMarkdownAnnotatedString(content, linkText, linkTextStyle, codeStyle, annotator)
     pop()
     if (annotation != null) pop()
 }
 
+@Deprecated(
+    "Use the non composable `appendAutoLink` function instead. This function will be removed in a future release.",
+    ReplaceWith("appendAutoLink(content, node, LocalMarkdownTypography.current.linkTextSpanStyle)", "com.mikepenz.markdown.compose.LocalMarkdownTypography")
+)
 @Composable
 fun AnnotatedString.Builder.appendAutoLink(content: String, node: ASTNode) {
+    appendAutoLink(content, node, LocalMarkdownTypography.current.linkTextSpanStyle)
+}
+
+/**
+ * Appends an auto-detected link to the `AnnotatedString.Builder`.
+ *
+ * @param content The content string.
+ * @param node The AST node representing the auto link.
+ * @param linkTextStyle The style to apply to the link text.
+ */
+fun AnnotatedString.Builder.appendAutoLink(
+    content: String,
+    node: ASTNode,
+    linkTextStyle: SpanStyle,
+) {
     val targetNode = node.children.firstOrNull {
         it.type.name == MarkdownElementTypes.AUTOLINK.name
     } ?: node
     val destination = targetNode.getUnescapedTextInNode(content)
     pushStringAnnotation(MARKDOWN_TAG_URL, (destination))
-    val linkColor = LocalMarkdownColors.current.linkText
-    val linkTextStyle = LocalMarkdownTypography.current.link.copy(color = linkColor).toSpanStyle()
     pushStyle(linkTextStyle)
     append(destination)
     pop()
 }
 
+@Deprecated("Use the non composable `buildMarkdownAnnotatedString` function instead. This function will be removed in a future release.")
+@Composable
+fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, node: ASTNode) = buildMarkdownAnnotatedString(
+    content = content,
+    node = node,
+    linkTextStyle = LocalMarkdownTypography.current.linkTextSpanStyle,
+    codeStyle = LocalMarkdownTypography.current.codeSpanStyle,
+    annotator = LocalMarkdownAnnotator.current
+)
+
 /**
  * Builds an [AnnotatedString] with the contents of the given Markdown [ASTNode] node.
  *
@@ -62,11 +173,26 @@ fun AnnotatedString.Builder.appendAutoLink(content: String, node: ASTNode) {
  * - Strong
  * - ...
  */
-@Composable
-fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, node: ASTNode) {
-    buildMarkdownAnnotatedString(content, node.children)
+fun AnnotatedString.Builder.buildMarkdownAnnotatedString(
+    content: String,
+    node: ASTNode,
+    linkTextStyle: SpanStyle,
+    codeStyle: SpanStyle,
+    annotator: MarkdownAnnotator? = null,
+) {
+    buildMarkdownAnnotatedString(content, node.children, linkTextStyle, codeStyle, annotator)
 }
 
+@Deprecated("Use the non composable `buildMarkdownAnnotatedString` function instead. This function will be removed in a future release.")
+@Composable
+fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, children: List<ASTNode>) = buildMarkdownAnnotatedString(
+    content = content,
+    children = children,
+    linkTextStyle = LocalMarkdownTypography.current.linkTextSpanStyle,
+    codeStyle = LocalMarkdownTypography.current.codeSpanStyle,
+    annotator = LocalMarkdownAnnotator.current
+)
+
 /**
  * Builds an [AnnotatedString] with the contents of the given Markdown [ASTNode] node.
  *
@@ -76,18 +202,23 @@ fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, node: 
  * - Strong
  * - ...
  */
-@Composable
-fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, children: List<ASTNode>) {
-    val annotator = LocalMarkdownAnnotator.current.annotate
-
+fun AnnotatedString.Builder.buildMarkdownAnnotatedString(
+    content: String,
+    children: List<ASTNode>,
+    linkTextStyle: SpanStyle,
+    codeStyle: SpanStyle,
+    annotator: MarkdownAnnotator? = null,
+) {
+    val annotate = annotator?.annotate
     var skipIfNext: Any? = null
     children.forEach { child ->
         if (skipIfNext == null || skipIfNext != child.type) {
-            if (annotator == null || !annotator(content, child)) {
+            if (annotate == null || !annotate(content, child)) {
                 val parentType = child.parent?.type
+
                 when (child.type) {
                     // Element types
-                    MarkdownElementTypes.PARAGRAPH -> buildMarkdownAnnotatedString(content, child)
+                    MarkdownElementTypes.PARAGRAPH -> buildMarkdownAnnotatedString(content, child, linkTextStyle, codeStyle, annotator)
                     MarkdownElementTypes.IMAGE -> child.findChildOfTypeRecursive(
                         MarkdownElementTypes.LINK_DESTINATION
                     )?.let {
@@ -96,46 +227,40 @@ fun AnnotatedString.Builder.buildMarkdownAnnotatedString(content: String, childr
 
                     MarkdownElementTypes.EMPH -> {
                         pushStyle(SpanStyle(fontStyle = FontStyle.Italic))
-                        buildMarkdownAnnotatedString(content, child)
+                        buildMarkdownAnnotatedString(content, child, linkTextStyle, codeStyle, annotator)
                         pop()
                     }
 
                     MarkdownElementTypes.STRONG -> {
                         pushStyle(SpanStyle(fontWeight = FontWeight.Bold))
-                        buildMarkdownAnnotatedString(content, child)
+                        buildMarkdownAnnotatedString(content, child, linkTextStyle, codeStyle, annotator)
                         pop()
                     }
 
                     GFMElementTypes.STRIKETHROUGH -> {
                         pushStyle(SpanStyle(textDecoration = TextDecoration.LineThrough))
-                        buildMarkdownAnnotatedString(content, child)
+                        buildMarkdownAnnotatedString(content, child, linkTextStyle, codeStyle, annotator)
                         pop()
                     }
 
                     MarkdownElementTypes.CODE_SPAN -> {
-                        val codeStyle = LocalMarkdownTypography.current.inlineCode
-                        pushStyle(
-                            codeStyle.copy(
-                                color = LocalMarkdownColors.current.inlineCodeText,
-                                background = LocalMarkdownColors.current.inlineCodeBackground
-                            ).toSpanStyle()
-                        )
+                        pushStyle(codeStyle)
                         append(' ')
-                        buildMarkdownAnnotatedString(content, child.children.innerList())
+                        buildMarkdownAnnotatedString(content, child.children.innerList(), linkTextStyle, codeStyle, annotator)
                         append(' ')
                         pop()
                     }
 
-                    MarkdownElementTypes.AUTOLINK -> appendAutoLink(content, child)
-                    MarkdownElementTypes.INLINE_LINK -> appendMarkdownLink(content, child)
-                    MarkdownElementTypes.SHORT_REFERENCE_LINK -> appendMarkdownLink(content, child)
-                    MarkdownElementTypes.FULL_REFERENCE_LINK -> appendMarkdownLink(content, child)
+                    MarkdownElementTypes.AUTOLINK -> appendAutoLink(content, child, linkTextStyle)
+                    MarkdownElementTypes.INLINE_LINK -> appendMarkdownLink(content, child, linkTextStyle, codeStyle, annotator)
+                    MarkdownElementTypes.SHORT_REFERENCE_LINK -> appendMarkdownLink(content, child, linkTextStyle, codeStyle, annotator)
+                    MarkdownElementTypes.FULL_REFERENCE_LINK -> appendMarkdownLink(content, child, linkTextStyle, codeStyle, annotator)
 
                     // Token Types
                     MarkdownTokenTypes.TEXT -> append(child.getUnescapedTextInNode(content))
                     GFMTokenTypes.GFM_AUTOLINK -> if (child.parent == MarkdownElementTypes.LINK_TEXT) {
                         append(child.getUnescapedTextInNode(content))
-                    } else appendAutoLink(content, child)
+                    } else appendAutoLink(content, child, linkTextStyle)
 
                     MarkdownTokenTypes.SINGLE_QUOTE -> append('\'')
                     MarkdownTokenTypes.DOUBLE_QUOTE -> append('\"')

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/EntityConverter.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/EntityConverter.kt
@@ -7,14 +7,14 @@ import org.intellij.markdown.html.entities.Entities
  * Removed HTML focused escaping by https://github.com/mikepenz/multiplatform-markdown-renderer/pull/222
  */
 object EntityConverter {
-    private const val escapeAllowedString = """!"#\$%&'\(\)\*\+,\-.\/:;<=>\?@\[\\\]\^_`{\|}~"""
+    private const val ESCAPE_ALLOWED_STRING = """!"#\$%&'\(\)\*\+,\-.\/:;<=>\?@\[\\\]\^_`{\|}~"""
     private val REGEX = Regex("""&(?:([a-zA-Z0-9]+)|#([0-9]{1,8})|#[xX]([a-fA-F0-9]{1,8}));|(["&<>])""")
-    private val REGEX_ESCAPES = Regex("${REGEX.pattern}|\\\\([$escapeAllowedString])")
+    private val REGEX_ESCAPES = Regex("${REGEX.pattern}|\\\\([$ESCAPE_ALLOWED_STRING])")
 
     fun replaceEntities(
         text: CharSequence,
         processEntities: Boolean,
-        processEscapes: Boolean
+        processEscapes: Boolean,
     ): String {
         val regex = if (processEscapes) REGEX_ESCAPES else REGEX
         return regex.replace(text) { match ->

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
@@ -1,5 +1,9 @@
 package com.mikepenz.markdown.utils
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.SpanStyle
+import com.mikepenz.markdown.compose.LocalMarkdownColors
+import com.mikepenz.markdown.model.MarkdownTypography
 import org.intellij.markdown.IElementType
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.getTextInNode
@@ -33,14 +37,44 @@ internal fun ASTNode.findChildOfTypeRecursive(type: IElementType): ASTNode? {
 
 /**
  * Helper function to drop the first and last element in the children list.
- * E.g. we don't want to render the brackets of a link
+ * E.g., we don't want to render the brackets of a link
  */
 internal fun List<ASTNode>.innerList(): List<ASTNode> = this.subList(1, this.size - 1)
 
+/**
+ * Extension function for `ASTNode` that retrieves the unescaped text within the node.
+ *
+ * This function first gets the text within the node, then converts it to a string.
+ * It then uses `EntityConverter.replaceEntities` to replace any escaped entities
+ * in the text, ensuring that the text is properly unescaped.
+ *
+ * @param allFileText The complete text of the file, which is used to extract the text within the node.
+ * @return The unescaped text within the node.
+ */
 fun ASTNode.getUnescapedTextInNode(allFileText: CharSequence): String {
     val escapedText = getTextInNode(allFileText).toString()
-    return EntityConverter.replaceEntities(escapedText,
+    return EntityConverter.replaceEntities(
+        escapedText,
         processEntities = false,
         processEscapes = true
     )
 }
+
+/**
+ * Extension property to get the `SpanStyle` for link text.
+ * This style is defined by the `link` typography and the current markdown colors.
+ */
+val MarkdownTypography.linkTextSpanStyle: SpanStyle
+    @Composable
+    get() = link.copy(color = LocalMarkdownColors.current.linkText).toSpanStyle()
+
+/**
+ * Extension property to get the `SpanStyle` for inline code text.
+ * This style is defined by the `inlineCode` typography and the current markdown colors.
+ */
+val MarkdownTypography.codeSpanStyle: SpanStyle
+    @Composable
+    get() = inlineCode.copy(
+        color = LocalMarkdownColors.current.inlineCodeText,
+        background = LocalMarkdownColors.current.inlineCodeBackground
+    ).toSpanStyle()


### PR DESCRIPTION
- rework `AnnotatedString` extensions to no longer be composable functions, instead get the actual style passed in
  - ensure we can use the string builders without compose available and offer the ability to build custom `Text` components benefitting from the markdown parsing and annotation capabilities
- deprecate prior composable functions