### PR TITLE
Replace API to disable animation for `MarkdownText`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,19 @@ Markdown(
 )
 ```
 
+### Disable Animation
+
+By default, the `MarkdownText` animates size changes (if images are loaded).
+
+```kotlin
+Markdown(
+    content,
+    animations = markdownAnimations(
+        animateTextSize = { this /** No animation */ }
+    ),
+}
+```
+
 ### Extended spans
 
 Starting with 0.16.0 the library includes support

--- a/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/Markdown.kt
+++ b/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/Markdown.kt
@@ -5,18 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.markdownComponents
-import com.mikepenz.markdown.model.ImageTransformer
-import com.mikepenz.markdown.model.NoOpImageTransformerImpl
-import com.mikepenz.markdown.model.MarkdownAnnotator
-import com.mikepenz.markdown.model.MarkdownColors
-import com.mikepenz.markdown.model.MarkdownDimens
-import com.mikepenz.markdown.model.MarkdownExtendedSpans
-import com.mikepenz.markdown.model.MarkdownPadding
-import com.mikepenz.markdown.model.MarkdownTypography
-import com.mikepenz.markdown.model.markdownAnnotator
-import com.mikepenz.markdown.model.markdownDimens
-import com.mikepenz.markdown.model.markdownExtendedSpans
-import com.mikepenz.markdown.model.markdownPadding
+import com.mikepenz.markdown.model.*
 import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 
@@ -33,16 +22,18 @@ fun Markdown(
     annotator: MarkdownAnnotator = markdownAnnotator(),
     extendedSpans: MarkdownExtendedSpans = markdownExtendedSpans(),
     components: MarkdownComponents = markdownComponents(),
+    animations: MarkdownAnimations = markdownAnimations(),
 ) = com.mikepenz.markdown.compose.Markdown(
-    content,
-    colors,
-    typography,
-    modifier,
-    padding,
-    dimens,
-    flavour,
-    imageTransformer,
-    annotator,
-    extendedSpans,
-    components,
+    content = content,
+    colors = colors,
+    typography = typography,
+    modifier = modifier,
+    padding = padding,
+    dimens = dimens,
+    flavour = flavour,
+    imageTransformer = imageTransformer,
+    annotator = annotator,
+    extendedSpans = extendedSpans,
+    components = components,
+    animations = animations,
 )

--- a/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/Markdown.kt
+++ b/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/Markdown.kt
@@ -5,18 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.markdownComponents
-import com.mikepenz.markdown.model.ImageTransformer
-import com.mikepenz.markdown.model.NoOpImageTransformerImpl
-import com.mikepenz.markdown.model.MarkdownAnnotator
-import com.mikepenz.markdown.model.MarkdownColors
-import com.mikepenz.markdown.model.MarkdownDimens
-import com.mikepenz.markdown.model.MarkdownExtendedSpans
-import com.mikepenz.markdown.model.MarkdownPadding
-import com.mikepenz.markdown.model.MarkdownTypography
-import com.mikepenz.markdown.model.markdownAnnotator
-import com.mikepenz.markdown.model.markdownDimens
-import com.mikepenz.markdown.model.markdownExtendedSpans
-import com.mikepenz.markdown.model.markdownPadding
+import com.mikepenz.markdown.model.*
 import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 
@@ -33,16 +22,18 @@ fun Markdown(
     annotator: MarkdownAnnotator = markdownAnnotator(),
     extendedSpans: MarkdownExtendedSpans = markdownExtendedSpans(),
     components: MarkdownComponents = markdownComponents(),
+    animations: MarkdownAnimations = markdownAnimations(),
 ) = com.mikepenz.markdown.compose.Markdown(
-    content,
-    colors,
-    typography,
-    modifier,
-    padding,
-    dimens,
-    flavour,
-    imageTransformer,
-    annotator,
-    extendedSpans,
-    components,
+    content = content,
+    colors = colors,
+    typography = typography,
+    modifier = modifier,
+    padding = padding,
+    dimens = dimens,
+    flavour = flavour,
+    imageTransformer = imageTransformer,
+    annotator = annotator,
+    extendedSpans = extendedSpans,
+    components = components,
+    animations = animations,
 )

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/ComposeLocal.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/ComposeLocal.kt
@@ -4,17 +4,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
 import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.markdownComponents
-import com.mikepenz.markdown.model.BulletHandler
-import com.mikepenz.markdown.model.DefaultMarkdownAnnotator
-import com.mikepenz.markdown.model.DefaultMarkdownExtendedSpans
-import com.mikepenz.markdown.model.ImageTransformer
-import com.mikepenz.markdown.model.MarkdownAnnotator
-import com.mikepenz.markdown.model.MarkdownColors
-import com.mikepenz.markdown.model.MarkdownDimens
-import com.mikepenz.markdown.model.MarkdownExtendedSpans
-import com.mikepenz.markdown.model.MarkdownPadding
-import com.mikepenz.markdown.model.MarkdownTypography
-import com.mikepenz.markdown.model.ReferenceLinkHandler
+import com.mikepenz.markdown.model.*
 
 /**
  * The CompositionLocal to provide functionality related to transforming the bullet of an ordered list
@@ -91,4 +81,11 @@ val LocalMarkdownExtendedSpans = compositionLocalOf<MarkdownExtendedSpans> {
  */
 val LocalMarkdownComponents = compositionLocalOf<MarkdownComponents> {
     return@compositionLocalOf markdownComponents()
+}
+
+/**
+ * Local [MarkdownAnimations] provider
+ */
+val LocalMarkdownAnimations = compositionLocalOf<MarkdownAnimations> {
+    error("No local MarkdownAnimations")
 }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
@@ -45,6 +45,7 @@ fun Markdown(
     annotator: MarkdownAnnotator = markdownAnnotator(),
     extendedSpans: MarkdownExtendedSpans = markdownExtendedSpans(),
     components: MarkdownComponents = markdownComponents(),
+    animations: MarkdownAnimations = markdownAnimations(),
 ) {
     CompositionLocalProvider(
         LocalReferenceLinkHandler provides ReferenceLinkHandlerImpl(),
@@ -56,6 +57,7 @@ fun Markdown(
         LocalMarkdownAnnotator provides annotator,
         LocalMarkdownExtendedSpans provides extendedSpans,
         LocalMarkdownComponents provides components,
+        LocalMarkdownAnimations provides animations,
     ) {
         Column(modifier) {
             val parsedTree = MarkdownParser(flavour).buildMarkdownTreeFromString(content)

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
@@ -110,7 +110,6 @@ fun MarkdownText(
         }
     } else modifier
 
-
     val transformer = LocalImageTransformer.current
     val placeholderState by derivedStateOf {
         transformer.placeholderConfig(
@@ -128,7 +127,10 @@ fun MarkdownText(
                     imageState.setContainerSize(coordinates.size)
                 }
             }
-            .let { animations.animateTextSize(it) },
+            .let {
+                // for backwards compatibility still check the `animate` property
+                if (placeholderState.animate) animations.animateTextSize(it) else it
+            },
         style = style,
         color = LocalMarkdownColors.current.text,
         inlineContent = mapOf(

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
@@ -1,6 +1,5 @@
 package com.mikepenz.markdown.compose.elements
 
-import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
@@ -75,6 +74,7 @@ fun MarkdownText(
     style: TextStyle = LocalMarkdownTypography.current.text,
     onTextLayout: (TextLayoutResult) -> Unit,
 ) {
+    val animations = LocalMarkdownAnimations.current
     val uriHandler = LocalUriHandler.current
     val referenceLinkHandler = LocalReferenceLinkHandler.current
     val layoutResult = remember { mutableStateOf<TextLayoutResult?>(null) }
@@ -128,9 +128,7 @@ fun MarkdownText(
                     imageState.setContainerSize(coordinates.size)
                 }
             }
-            .let {
-                if (placeholderState.animate) it.animateContentSize() else it
-            },
+            .let { animations.animateTextSize(it) },
         style = style,
         color = LocalMarkdownColors.current.text,
         inlineContent = mapOf(

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/ImageTransformer.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/ImageTransformer.kt
@@ -55,6 +55,7 @@ interface ImageTransformer {
 data class PlaceholderConfig(
     val size: Size,
     val verticalAlign: PlaceholderVerticalAlign = PlaceholderVerticalAlign.Bottom,
+    @Deprecated("This parameter is not used anymore and will be removed in the future.")
     val animate: Boolean = true,
 )
 

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownAnimations.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownAnimations.kt
@@ -1,0 +1,32 @@
+package com.mikepenz.markdown.model
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Modifier
+
+interface MarkdownAnimations {
+    /**
+     * Modifier used to animate [MarkdownText] size changes.
+     * This is mainly the case if inline images are loaded and their placeholder has a different size from the final image.
+     */
+    val animateTextSize: Modifier.() -> Modifier
+}
+
+@Immutable
+class DefaultMarkdownAnimation(
+    override val animateTextSize: Modifier.() -> Modifier,
+) : MarkdownAnimations
+
+@Composable
+fun markdownAnimations(
+    /**
+     * Modifier used to animate [MarkdownText] size changes.
+     * By default, this uses [animateContentSize].
+     *
+     * It's possible to modify the animation or alternatively return` {this} to not animate at all.
+     */
+    animateTextSize: Modifier.() -> Modifier = { animateContentSize() },
+): MarkdownAnimations = DefaultMarkdownAnimation(
+    animateTextSize
+)


### PR DESCRIPTION
- add new API to configure animation on the `MarkdownText`
  - This API allows modification of the animation, alternatively it's possible to disable animations
  - FIX https://github.com/mikepenz/multiplatform-markdown-renderer/issues/244

```kotlin
Markdown(
    content,
    animations = markdownAnimations(
        animateTextSize = { this /** No animation */ }
    ),
}
```