### PR TITLE
Add support for tables in markdown renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,21 @@ Markdown(
 )
 ```
 
+### Table Support
+
+Starting with 0.30.0, the library includes support for rendering tables in markdown. The `Markdown` composable will automatically handle table elements in your markdown content.
+
+```kotlin
+val markdown = """
+| Header 1 | Header 2 |
+|----------|----------|
+| Cell 1   | Cell 2   |
+| Cell 3   | Cell 4   |
+""".trimIndent()
+
+Markdown(markdown)
+```
+
 </p>
 </details>
 

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/ComposeLocal.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/ComposeLocal.kt
@@ -89,3 +89,10 @@ val LocalMarkdownComponents = compositionLocalOf<MarkdownComponents> {
 val LocalMarkdownAnimations = compositionLocalOf<MarkdownAnimations> {
     error("No local MarkdownAnimations")
 }
+
+/**
+ * Local [MarkdownTable] provider
+ */
+val LocalMarkdownTable = compositionLocalOf<MarkdownComponent> {
+    error("No local MarkdownTable")
+}

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
@@ -24,6 +24,7 @@ import org.intellij.markdown.MarkdownElementTypes.PARAGRAPH
 import org.intellij.markdown.MarkdownElementTypes.SETEXT_1
 import org.intellij.markdown.MarkdownElementTypes.SETEXT_2
 import org.intellij.markdown.MarkdownElementTypes.UNORDERED_LIST
+import org.intellij.markdown.MarkdownElementTypes.TABLE
 import org.intellij.markdown.MarkdownTokenTypes.Companion.EOL
 import org.intellij.markdown.MarkdownTokenTypes.Companion.HORIZONTAL_RULE
 import org.intellij.markdown.MarkdownTokenTypes.Companion.TEXT
@@ -106,6 +107,7 @@ internal fun ColumnScope.handleElement(
         IMAGE -> components.image(this@handleElement, model)
         LINK_DEFINITION -> components.linkDefinition(this@handleElement, model)
         HORIZONTAL_RULE -> components.horizontalRule(this@handleElement, model)
+        TABLE -> components.table(this@handleElement, model)
         else -> {
             handled = components.custom?.invoke(this@handleElement, node.type, model) != null
         }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/components/MarkdownComponents.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/components/MarkdownComponents.kt
@@ -51,6 +51,7 @@ fun markdownComponents(
     image: MarkdownComponent = CurrentComponentsBridge.image,
     linkDefinition: MarkdownComponent = CurrentComponentsBridge.linkDefinition,
     horizontalRule: MarkdownComponent = CurrentComponentsBridge.horizontalRule,
+    table: MarkdownComponent = CurrentComponentsBridge.table,
     custom: CustomMarkdownComponent? = CurrentComponentsBridge.custom,
 ): MarkdownComponents = DefaultMarkdownComponents(
     text = text,
@@ -72,6 +73,7 @@ fun markdownComponents(
     image = image,
     linkDefinition = linkDefinition,
     horizontalRule = horizontalRule,
+    table = table,
     custom = custom,
 )
 
@@ -99,6 +101,7 @@ interface MarkdownComponents {
     val image: MarkdownComponent
     val linkDefinition: MarkdownComponent
     val horizontalRule: MarkdownComponent
+    val table: MarkdownComponent
     val custom: CustomMarkdownComponent?
 }
 
@@ -122,6 +125,7 @@ private class DefaultMarkdownComponents(
     override val image: MarkdownComponent,
     override val linkDefinition: MarkdownComponent,
     override val horizontalRule: MarkdownComponent,
+    override val table: MarkdownComponent,
     override val custom: CustomMarkdownComponent?,
 ) : MarkdownComponents
 
@@ -193,6 +197,9 @@ object CurrentComponentsBridge {
     }
     val horizontalRule: MarkdownComponent = {
         MarkdownDivider(Modifier.fillMaxWidth())
+    }
+    val table: MarkdownComponent = {
+        MarkdownTable(it)
     }
     val custom: CustomMarkdownComponent? = null
 }


### PR DESCRIPTION
Add support for tables in the markdown-renderer.

* **MarkdownComponents.kt**: Add a new `MarkdownComponent` for tables. Update `markdownComponents` function, `MarkdownComponents` interface, `DefaultMarkdownComponents` class, and `CurrentComponentsBridge` object to include the new table component.
* **ComposeLocal.kt**: Add a local provider for the new table component.
* **Markdown.kt**: Handle the new table component in the `handleElement` function.
* **README.md**: Update documentation to include information about the new table support.

