### PR TITLE
Update Code Highlights To Automatically Account For Dark Mode

### DIFF
--- a/multiplatform-markdown-renderer-code/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHighlightedCode.kt
+++ b/multiplatform-markdown-renderer-code/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHighlightedCode.kt
@@ -54,11 +54,13 @@ fun MarkdownHighlightedCode(
     val codeBackgroundCornerSize = LocalMarkdownDimens.current.codeBackgroundCornerSize
     val codeBlockPadding = LocalMarkdownPadding.current.codeBlock
     val syntaxLanguage = remember(language) { language?.let { SyntaxLanguage.getByName(it) } }
+    val isDarkMode = LocalMarkdownColors.current.codeBackground.luminance() > 0.5
 
     val codeHighlights by remembering(code) {
         derivedStateOf {
             highlights
                 .code(code)
+                .theme(SyntaxThemes.default(darkMode = isDarkMode))
                 .let { if (syntaxLanguage != null) it.language(syntaxLanguage) else it }
                 .build()
         }


### PR DESCRIPTION
I noticed when playing around with this today that the code highlighting default behavior doesn't account for light and dark mode. With the default theme being darcula anything that is highlighted with the mark or code color codes are basically illegible. 

To solve that I'm checking the luminance of the code background color to see if that's light or dark and applying that to the highlights theme.

Nothing major but a nice little quality of life improvement. TY for the great library! I might try to tackle some other things in the future when I have time.
| Before | After |
| --- | --- |
| <img width="363" alt="LightThemeDarkMode" src="https://github.com/user-attachments/assets/36a343ff-0201-426a-9eca-862552cd4be7" /> | <img width="364" alt="DarkThemeDarkMode" src="https://github.com/user-attachments/assets/6b4960ba-2056-4185-b7a4-e0d6a733fcd7" /> |




