### PR TITLE
Update Code Highlights To Automatically Account For Dark Mode

### DIFF
--- a/multiplatform-markdown-renderer-code/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHighlightedCode.kt
+++ b/multiplatform-markdown-renderer-code/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHighlightedCode.kt
@@ -24,10 +24,26 @@ import dev.snipme.highlights.model.SyntaxLanguage
 import org.intellij.markdown.ast.ASTNode
 
 /** Default definition for the [MarkdownHighlightedCodeFence]. Uses default theme, attempts to apply language from markdown. */
-val highlightedCodeFence: MarkdownComponent = { MarkdownHighlightedCodeFence(it.content, it.node) }
+val highlightedCodeFence: MarkdownComponent = {
+    MarkdownHighlightedCodeFence(
+        content = it.content,
+        node = it.node,
+        highlights = Highlights.Builder(
+            theme = SyntaxThemes.default(darkMode = isDarkMode())
+        ),
+    )
+}
 
 /** Default definition for the [MarkdownHighlightedCodeBlock]. Uses default theme, attempts to apply language from markdown. */
-val highlightedCodeBlock: MarkdownComponent = { MarkdownHighlightedCodeBlock(it.content, it.node) }
+val highlightedCodeBlock: MarkdownComponent = {
+    MarkdownHighlightedCodeBlock(
+        content = it.content,
+        node = it.node,
+        highlights = Highlights.Builder(
+            theme = SyntaxThemes.default(darkMode = isDarkMode())
+        ),
+    )
+}
 
 @Composable
 fun MarkdownHighlightedCodeFence(content: String, node: ASTNode, highlights: Highlights.Builder = Highlights.Builder()) {
@@ -54,13 +70,11 @@ fun MarkdownHighlightedCode(
     val codeBackgroundCornerSize = LocalMarkdownDimens.current.codeBackgroundCornerSize
     val codeBlockPadding = LocalMarkdownPadding.current.codeBlock
     val syntaxLanguage = remember(language) { language?.let { SyntaxLanguage.getByName(it) } }
-    val isDarkMode = LocalMarkdownColors.current.codeBackground.luminance() > 0.5
 
     val codeHighlights by remembering(code) {
         derivedStateOf {
             highlights
                 .code(code)
-                .theme(SyntaxThemes.default(darkMode = isDarkMode))
                 .let { if (syntaxLanguage != null) it.language(syntaxLanguage) else it }
                 .build()
         }
@@ -109,3 +123,6 @@ internal inline fun <T, K> remembering(
 internal fun AnnotatedString.Builder.text(text: String, style: SpanStyle = SpanStyle()) = withStyle(style = style) {
     append(text)
 }
+
+@Composable
+internal fun isDarkMode() = LocalMarkdownColors.current.codeBackground.luminance() > 0.5

--- a/multiplatform-markdown-renderer-code/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHighlightedCode.kt
+++ b/multiplatform-markdown-renderer-code/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHighlightedCode.kt
@@ -1,6 +1,7 @@
 package com.mikepenz.markdown.compose.elements
 
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -29,7 +30,7 @@ val highlightedCodeFence: MarkdownComponent = {
         content = it.content,
         node = it.node,
         highlights = Highlights.Builder(
-            theme = SyntaxThemes.default(darkMode = isDarkMode())
+            theme = SyntaxThemes.default(darkMode = isSystemInDarkTheme())
         ),
     )
 }
@@ -40,7 +41,7 @@ val highlightedCodeBlock: MarkdownComponent = {
         content = it.content,
         node = it.node,
         highlights = Highlights.Builder(
-            theme = SyntaxThemes.default(darkMode = isDarkMode())
+            theme = SyntaxThemes.default(darkMode = isSystemInDarkTheme())
         ),
     )
 }
@@ -123,6 +124,3 @@ internal inline fun <T, K> remembering(
 internal fun AnnotatedString.Builder.text(text: String, style: SpanStyle = SpanStyle()) = withStyle(style = style) {
     append(text)
 }
-
-@Composable
-internal fun isDarkMode() = LocalMarkdownColors.current.codeBackground.luminance() > 0.5

--- a/multiplatform-markdown-renderer-code/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHighlightedCode.kt
+++ b/multiplatform-markdown-renderer-code/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHighlightedCode.kt
@@ -39,7 +39,7 @@ fun MarkdownHighlightedCodeFence(
         theme = SyntaxThemes.default(
             darkMode = isSystemInDarkTheme()
         )
-    )
+    ),
 ) {
     MarkdownCodeFence(content, node) { code, language ->
         MarkdownHighlightedCode(code, language, highlights)
@@ -54,7 +54,7 @@ fun MarkdownHighlightedCodeBlock(
         theme = SyntaxThemes.default(
             darkMode = isSystemInDarkTheme()
         )
-    )
+    ),
 ) {
     MarkdownCodeBlock(content, node) { code, language ->
         MarkdownHighlightedCode(code, language, highlights)

--- a/multiplatform-markdown-renderer-code/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHighlightedCode.kt
+++ b/multiplatform-markdown-renderer-code/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHighlightedCode.kt
@@ -22,6 +22,7 @@ import dev.snipme.highlights.Highlights
 import dev.snipme.highlights.model.BoldHighlight
 import dev.snipme.highlights.model.ColorHighlight
 import dev.snipme.highlights.model.SyntaxLanguage
+import dev.snipme.highlights.model.SyntaxThemes
 import org.intellij.markdown.ast.ASTNode
 
 /** Default definition for the [MarkdownHighlightedCodeFence]. Uses default theme, attempts to apply language from markdown. */

--- a/multiplatform-markdown-renderer-code/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHighlightedCode.kt
+++ b/multiplatform-markdown-renderer-code/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHighlightedCode.kt
@@ -54,11 +54,13 @@ fun MarkdownHighlightedCode(
     val codeBackgroundCornerSize = LocalMarkdownDimens.current.codeBackgroundCornerSize
     val codeBlockPadding = LocalMarkdownPadding.current.codeBlock
     val syntaxLanguage = remember(language) { language?.let { SyntaxLanguage.getByName(it) } }
+    val isDarkMode = LocalMarkdownColors.current.codeBackground.luminance() > 0.5
 
     val codeHighlights by remembering(code) {
         derivedStateOf {
             highlights
                 .code(code)
+                .theme(SyntaxThemes.default(darkMode = isDarkMode))
                 .let { if (syntaxLanguage != null) it.language(syntaxLanguage) else it }
                 .build()
         }

--- a/multiplatform-markdown-renderer-code/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHighlightedCode.kt
+++ b/multiplatform-markdown-renderer-code/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHighlightedCode.kt
@@ -26,36 +26,36 @@ import dev.snipme.highlights.model.SyntaxThemes
 import org.intellij.markdown.ast.ASTNode
 
 /** Default definition for the [MarkdownHighlightedCodeFence]. Uses default theme, attempts to apply language from markdown. */
-val highlightedCodeFence: MarkdownComponent = {
-    MarkdownHighlightedCodeFence(
-        content = it.content,
-        node = it.node,
-        highlights = Highlights.Builder(
-            theme = SyntaxThemes.default(darkMode = isSystemInDarkTheme())
-        ),
-    )
-}
+val highlightedCodeFence: MarkdownComponent = { MarkdownHighlightedCodeFence(it.content, it.node) }
 
 /** Default definition for the [MarkdownHighlightedCodeBlock]. Uses default theme, attempts to apply language from markdown. */
-val highlightedCodeBlock: MarkdownComponent = {
-    MarkdownHighlightedCodeBlock(
-        content = it.content,
-        node = it.node,
-        highlights = Highlights.Builder(
-            theme = SyntaxThemes.default(darkMode = isSystemInDarkTheme())
-        ),
-    )
-}
+val highlightedCodeBlock: MarkdownComponent = { MarkdownHighlightedCodeBlock(it.content, it.node) }
 
 @Composable
-fun MarkdownHighlightedCodeFence(content: String, node: ASTNode, highlights: Highlights.Builder = Highlights.Builder()) {
+fun MarkdownHighlightedCodeFence(
+    content: String,
+    node: ASTNode,
+    highlights: Highlights.Builder = Highlights.Builder(
+        theme = SyntaxThemes.default(
+            darkMode = isSystemInDarkTheme()
+        )
+    )
+) {
     MarkdownCodeFence(content, node) { code, language ->
         MarkdownHighlightedCode(code, language, highlights)
     }
 }
 
 @Composable
-fun MarkdownHighlightedCodeBlock(content: String, node: ASTNode, highlights: Highlights.Builder = Highlights.Builder()) {
+fun MarkdownHighlightedCodeBlock(
+    content: String,
+    node: ASTNode,
+    highlights: Highlights.Builder = Highlights.Builder(
+        theme = SyntaxThemes.default(
+            darkMode = isSystemInDarkTheme()
+        )
+    )
+) {
     MarkdownCodeBlock(content, node) { code, language ->
         MarkdownHighlightedCode(code, language, highlights)
     }


### PR DESCRIPTION
I noticed when playing around with this today that the code highlighting default definitions don't account for light and dark mode. With the default theme being darcula anything that is highlighted with the mark or code colors are basically illegible.

To solve this I added default theme to the definitions and added a helper function to check what mode we're in. I'm checking the luminance of the code background color to see if that's light or dark and applying that to the highlights theme.

Nothing major but I thought it might be a nice little quality of life improvement for default behavior to respect theme. Originally I made a change in `MarkdownHighlightedCode` without thinking too much about it then but then realized as soon as I put up the previous PR that it was a very wrong approach so I closed that PR (also the first commit in this PR) 😅.

Also there might be a better place or way to do this so no worries if it's a no go here. It was just a quick thought once I realized what was going on. I did think that maybe it would be nice if code background always determined highlighting theme but that seems like a larger can'o'worms and breaks some users decision making abilities.

Anyway, TY for the great library! It's been fun to play around with and I can see some things I might try to tackle in the future when I have time (looking at you tables!).

| Before | After |
| --- | --- |
| <img width="363" alt="LightThemeDarkMode" src="https://github.com/user-attachments/assets/36a343ff-0201-426a-9eca-862552cd4be7" /> | <img width="364" alt="DarkThemeDarkMode" src="https://github.com/user-attachments/assets/6b4960ba-2056-4185-b7a4-e0d6a733fcd7" /> |



