### PR TITLE
Refactor to use `withLink` introduced in Compose 1.7 for links in the annotated string

### DIFF
--- a/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/MarkdownTypography.kt
+++ b/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/MarkdownTypography.kt
@@ -3,6 +3,7 @@ package com.mikepenz.markdown.m2
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
@@ -28,11 +29,24 @@ fun markdownTypography(
     bullet: TextStyle = MaterialTheme.typography.body1,
     list: TextStyle = MaterialTheme.typography.body1,
     link: TextStyle = MaterialTheme.typography.body1.copy(
-        fontWeight = FontWeight.Bold,
-        textDecoration = TextDecoration.Underline
+        fontWeight = FontWeight.Bold, textDecoration = TextDecoration.Underline
     ),
+    textLink: TextLinkStyles = TextLinkStyles(style = link.toSpanStyle()),
 ): MarkdownTypography = DefaultMarkdownTypography(
-    h1 = h1, h2 = h2, h3 = h3, h4 = h4, h5 = h5, h6 = h6,
-    text = text, quote = quote, code = code, inlineCode = inlineCode, paragraph = paragraph,
-    ordered = ordered, bullet = bullet, list = list, link = link,
+    h1 = h1,
+    h2 = h2,
+    h3 = h3,
+    h4 = h4,
+    h5 = h5,
+    h6 = h6,
+    text = text,
+    quote = quote,
+    code = code,
+    inlineCode = inlineCode,
+    paragraph = paragraph,
+    ordered = ordered,
+    bullet = bullet,
+    list = list,
+    link = link,
+    textLink = textLink
 )

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/annotator/AnnotatorSettings.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/annotator/AnnotatorSettings.kt
@@ -1,0 +1,83 @@
+package com.mikepenz.markdown.annotator
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.LinkInteractionListener
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.TextStyle
+import com.mikepenz.markdown.compose.LocalMarkdownAnnotator
+import com.mikepenz.markdown.compose.LocalMarkdownTypography
+import com.mikepenz.markdown.compose.LocalReferenceLinkHandler
+import com.mikepenz.markdown.model.MarkdownAnnotator
+import com.mikepenz.markdown.model.ReferenceLinkHandler
+import com.mikepenz.markdown.utils.codeSpanStyle
+
+@Stable
+interface AnnotatorSettings {
+    /** Represents the [TextLinkStyles] applied onto links within this annotated string */
+    val linkTextSpanStyle: TextLinkStyles
+
+    /** Represents the [SpanStyle] applied onto code inline blocks within this annotated string */
+    val codeSpanStyle: SpanStyle
+
+    /** Provides custom interception logic for building this annotated string */
+    val annotator: MarkdownAnnotator?
+
+    /** Represents the [ReferenceLinkHandler] used to store and find links when clicks on links occur. */
+    val referenceLinkHandler: ReferenceLinkHandler?
+
+    /** Represents the [LinkInteractionListener] used for links in this annotated string */
+    val linkInteractionListener: LinkInteractionListener?
+}
+
+@Immutable
+class DefaultAnnotatorSettings(
+    override val linkTextSpanStyle: TextLinkStyles,
+    override val codeSpanStyle: SpanStyle,
+    override val annotator: MarkdownAnnotator? = null,
+    override val referenceLinkHandler: ReferenceLinkHandler? = null,
+    override val linkInteractionListener: LinkInteractionListener? = null,
+) : AnnotatorSettings {
+    constructor(
+        style: TextStyle,
+        linkTextSpanStyle: TextLinkStyles = TextLinkStyles(style = style.toSpanStyle()),
+        codeSpanStyle: SpanStyle = style.toSpanStyle(),
+        annotator: MarkdownAnnotator? = null,
+        referenceLinkHandler: ReferenceLinkHandler? = null,
+        linkInteractionListener: LinkInteractionListener? = null,
+    ) : this(linkTextSpanStyle, codeSpanStyle, annotator, referenceLinkHandler, linkInteractionListener)
+}
+
+@Composable
+fun annotatorSettings(
+    linkTextSpanStyle: TextLinkStyles = LocalMarkdownTypography.current.textLink,
+    codeSpanStyle: SpanStyle = LocalMarkdownTypography.current.codeSpanStyle,
+    annotator: MarkdownAnnotator? = LocalMarkdownAnnotator.current,
+    referenceLinkHandler: ReferenceLinkHandler? = LocalReferenceLinkHandler.current,
+    uriHandler: UriHandler = LocalUriHandler.current,
+    linkInteractionListener: LinkInteractionListener? = object : LinkInteractionListener {
+        override fun onClick(link: LinkAnnotation) {
+            val annotationUrl = (link as? LinkAnnotation.Url)?.url
+            if (annotationUrl != null) {
+                val foundReference = referenceLinkHandler?.find(annotationUrl) ?: annotationUrl
+                // wait for finger up to navigate to the link
+                try {
+                    uriHandler.openUri(foundReference)
+                } catch (t: Throwable) {
+                    println("Could not open the provided url: $foundReference // ${t.message}")
+                }
+            }
+        }
+    },
+): AnnotatorSettings = DefaultAnnotatorSettings(
+    linkTextSpanStyle = linkTextSpanStyle,
+    codeSpanStyle = codeSpanStyle,
+    annotator = annotator,
+    referenceLinkHandler = referenceLinkHandler,
+    linkInteractionListener = linkInteractionListener,
+)

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownParagraph.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownParagraph.kt
@@ -4,12 +4,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import com.mikepenz.markdown.compose.LocalMarkdownAnnotator
+import com.mikepenz.markdown.annotator.annotatorSettings
+import com.mikepenz.markdown.annotator.buildMarkdownAnnotatedString
 import com.mikepenz.markdown.compose.LocalMarkdownTypography
-import com.mikepenz.markdown.compose.LocalReferenceLinkHandler
-import com.mikepenz.markdown.utils.buildMarkdownAnnotatedString
-import com.mikepenz.markdown.utils.codeSpanStyle
-import com.mikepenz.markdown.utils.linkTextSpanStyle
 import org.intellij.markdown.ast.ASTNode
 
 @Composable
@@ -19,20 +16,10 @@ fun MarkdownParagraph(
     modifier: Modifier = Modifier,
     style: TextStyle = LocalMarkdownTypography.current.paragraph,
 ) {
-    val annotator = LocalMarkdownAnnotator.current
-    val linkTextSpanStyle = LocalMarkdownTypography.current.linkTextSpanStyle
-    val codeSpanStyle = LocalMarkdownTypography.current.codeSpanStyle
-    val referenceLinkHandler = LocalReferenceLinkHandler.current
+    val annotatorSettings = annotatorSettings()
     val styledText = buildAnnotatedString {
         pushStyle(style.toSpanStyle())
-        buildMarkdownAnnotatedString(
-            content = content,
-            node = node,
-            linkTextStyle = linkTextSpanStyle,
-            codeStyle = codeSpanStyle,
-            annotator = annotator,
-            referenceLinkHandler = referenceLinkHandler
-        )
+        buildMarkdownAnnotatedString(content = content, node = node, annotatorSettings = annotatorSettings)
         pop()
     }
 

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownTable.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownTable.kt
@@ -24,15 +24,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.times
-import com.mikepenz.markdown.compose.LocalMarkdownAnnotator
+import com.mikepenz.markdown.annotator.annotatorSettings
+import com.mikepenz.markdown.annotator.buildMarkdownAnnotatedString
 import com.mikepenz.markdown.compose.LocalMarkdownColors
 import com.mikepenz.markdown.compose.LocalMarkdownDimens
-import com.mikepenz.markdown.compose.LocalMarkdownTypography
-import com.mikepenz.markdown.compose.LocalReferenceLinkHandler
 import com.mikepenz.markdown.compose.elements.material.MarkdownBasicText
-import com.mikepenz.markdown.utils.buildMarkdownAnnotatedString
-import com.mikepenz.markdown.utils.codeSpanStyle
-import com.mikepenz.markdown.utils.linkTextSpanStyle
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.findChildOfType
 import org.intellij.markdown.flavours.gfm.GFMElementTypes.HEADER
@@ -103,11 +99,8 @@ fun MarkdownTableHeader(
     maxLines: Int = 1,
     overflow: TextOverflow = TextOverflow.Ellipsis,
 ) {
-    val annotator = LocalMarkdownAnnotator.current
-    val linkTextSpanStyle = LocalMarkdownTypography.current.linkTextSpanStyle
-    val codeSpanStyle = LocalMarkdownTypography.current.codeSpanStyle
-    val referenceLinkHandler = LocalReferenceLinkHandler.current
     val tableCellPadding = LocalMarkdownDimens.current.tableCellPadding
+    val annotatorSettings = annotatorSettings()
     Row(
         verticalAlignment = verticalAlignment,
         modifier = Modifier.widthIn(tableWidth).height(IntrinsicSize.Max)
@@ -119,10 +112,7 @@ fun MarkdownTableHeader(
                         text = content.buildMarkdownAnnotatedString(
                             textNode = it,
                             style = style.copy(fontWeight = FontWeight.Bold),
-                            linkTextSpanStyle = linkTextSpanStyle,
-                            codeSpanStyle = codeSpanStyle,
-                            annotator = annotator,
-                            referenceLinkHandler = referenceLinkHandler
+                            annotatorSettings = annotatorSettings,
                         ),
                         style = style.copy(fontWeight = FontWeight.Bold),
                         color = LocalMarkdownColors.current.tableText,
@@ -146,11 +136,8 @@ fun MarkdownTableRow(
     maxLines: Int = 1,
     overflow: TextOverflow = TextOverflow.Ellipsis,
 ) {
-    val annotator = LocalMarkdownAnnotator.current
-    val linkTextSpanStyle = LocalMarkdownTypography.current.linkTextSpanStyle
-    val codeSpanStyle = LocalMarkdownTypography.current.codeSpanStyle
-    val referenceLinkHandler = LocalReferenceLinkHandler.current
     val tableCellPadding = LocalMarkdownDimens.current.tableCellPadding
+    val annotatorSettings = annotatorSettings()
     Row(
         verticalAlignment = verticalAlignment,
         modifier = Modifier.widthIn(tableWidth)
@@ -160,10 +147,7 @@ fun MarkdownTableRow(
                 text = content.buildMarkdownAnnotatedString(
                     textNode = cell,
                     style = style,
-                    linkTextSpanStyle = linkTextSpanStyle,
-                    codeSpanStyle = codeSpanStyle,
-                    annotator = annotator,
-                    referenceLinkHandler = referenceLinkHandler
+                    annotatorSettings = annotatorSettings,
                 ),
                 style = style,
                 color = LocalMarkdownColors.current.tableText,

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.Placeholder
@@ -79,12 +80,12 @@ fun MarkdownText(
     }
 
     // forward the `onTextLayout` to `extended-spans` if provided
-    val onTextLayout: (TextLayoutResult) -> Unit = if (extendedSpans != null) {
-        { result ->
-            extendedSpans.onTextLayout(result)
+    val onTextLayout: (TextLayoutResult, Color?) -> Unit = if (extendedSpans != null) {
+        { layoutResult, color ->
+            extendedSpans.onTextLayout(layoutResult, color)
         }
     } else {
-        {}
+        { _, _ -> }
     }
 
     // call drawBehind with the `extended-spans` if provided
@@ -100,8 +101,9 @@ fun MarkdownText(
     content: AnnotatedString,
     modifier: Modifier = Modifier,
     style: TextStyle = LocalMarkdownTypography.current.text,
-    onTextLayout: (TextLayoutResult) -> Unit,
+    onTextLayout: (TextLayoutResult, Color?) -> Unit,
 ) {
+    val baseColor = LocalMarkdownColors.current.text
     val animations = LocalMarkdownAnimations.current
     val layoutResult = remember { mutableStateOf<TextLayoutResult?>(null) }
     val imageState = rememberMarkdownImageState()
@@ -129,7 +131,7 @@ fun MarkdownText(
                 if (placeholderState.animate) animations.animateTextSize(it) else it
             },
         style = style,
-        color = LocalMarkdownColors.current.text,
+        color = baseColor,
         inlineContent = mapOf(
             MARKDOWN_TAG_IMAGE_URL to InlineTextContent(
                 Placeholder(
@@ -157,7 +159,7 @@ fun MarkdownText(
         ),
         onTextLayout = {
             layoutResult.value = it
-            onTextLayout.invoke(it)
+            onTextLayout.invoke(it, baseColor)
         }
     )
 }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/ExtendedSpanPainter.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/ExtendedSpanPainter.kt
@@ -6,6 +6,7 @@ package com.mikepenz.markdown.compose.extendedspans
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.style.ResolvedTextDirection.Ltr
@@ -22,6 +23,17 @@ abstract class ExtendedSpanPainter {
         text: AnnotatedString,
         builder: AnnotatedString.Builder,
     ): SpanStyle
+
+    /**
+     * Can be used for removing any existing text link styles from [text] so that they can be drawn manually.
+     */
+    abstract fun decorate(
+        linkAnnotation: LinkAnnotation,
+        start: Int,
+        end: Int,
+        text: AnnotatedString,
+        builder: AnnotatedString.Builder,
+    ): LinkAnnotation
 
     abstract fun drawInstructionsFor(
         layoutResult: TextLayoutResult,

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/ExtendedSpanPainter.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/ExtendedSpanPainter.kt
@@ -20,11 +20,11 @@ abstract class ExtendedSpanPainter {
         start: Int,
         end: Int,
         text: AnnotatedString,
-        builder: AnnotatedString.Builder
+        builder: AnnotatedString.Builder,
     ): SpanStyle
 
     abstract fun drawInstructionsFor(
-        layoutResult: TextLayoutResult
+        layoutResult: TextLayoutResult,
     ): SpanDrawInstructions
 
     /**
@@ -38,7 +38,7 @@ abstract class ExtendedSpanPainter {
     protected fun TextLayoutResult.getBoundingBoxes(
         startOffset: Int,
         endOffset: Int,
-        flattenForFullParagraphs: Boolean = false
+        flattenForFullParagraphs: Boolean = false,
     ): List<Rect> {
         if (startOffset == endOffset) {
             return emptyList()

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/ExtendedSpanPainter.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/ExtendedSpanPainter.kt
@@ -4,6 +4,7 @@
 package com.mikepenz.markdown.compose.extendedspans
 
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
@@ -37,6 +38,7 @@ abstract class ExtendedSpanPainter {
 
     abstract fun drawInstructionsFor(
         layoutResult: TextLayoutResult,
+        color: Color? = null,
     ): SpanDrawInstructions
 
     /**

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/ExtendedSpans.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/ExtendedSpans.kt
@@ -8,6 +8,7 @@ package com.mikepenz.markdown.compose.extendedspans
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.LinkAnnotation
@@ -78,10 +79,10 @@ class ExtendedSpans(
         }
     }
 
-    fun onTextLayout(layoutResult: TextLayoutResult) {
+    fun onTextLayout(layoutResult: TextLayoutResult, color: Color? = null) {
         layoutResult.checkIfExtendWasCalled()
         drawInstructions = painters.fastMap {
-            it.drawInstructionsFor(layoutResult)
+            it.drawInstructionsFor(layoutResult, color)
         }
     }
 

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/ExtendedSpans.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/ExtendedSpans.kt
@@ -66,7 +66,11 @@ class ExtendedSpans(
                 addUrlAnnotation(it.item, it.start, it.end)
             }
             text.getLinkAnnotations(start = 0, end = text.length).fastForEach { range ->
-                when (val item = range.item) {
+                val decorated = painters.fastFold(initial = range.item) { updated, painter ->
+                    painter.decorate(updated, range.start, range.end, text = text, builder = this)
+                }
+
+                when (val item = decorated) {
                     is LinkAnnotation.Url -> addLink(item, range.start, range.end)
                     is LinkAnnotation.Clickable -> addLink(item, range.start, range.end)
                 }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/ExtendedSpans.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/ExtendedSpans.kt
@@ -10,15 +10,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.buildAnnotatedString
-import com.mikepenz.markdown.compose.extendedspans.internal.fastFold
-import com.mikepenz.markdown.compose.extendedspans.internal.fastForEach
-import com.mikepenz.markdown.compose.extendedspans.internal.fastMap
+import androidx.compose.ui.util.fastFold
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastMap
 
 @Stable
 class ExtendedSpans(
-    vararg painters: ExtendedSpanPainter
+    vararg painters: ExtendedSpanPainter,
 ) {
     private val painters = painters.toList()
     internal var drawInstructions = emptyList<SpanDrawInstructions>()
@@ -59,6 +60,16 @@ class ExtendedSpans(
             }
             text.getTtsAnnotations(start = 0, end = text.length).fastForEach {
                 addTtsAnnotation(it.item, it.start, it.end)
+            }
+            @Suppress("DEPRECATION")
+            text.getUrlAnnotations(start = 0, end = text.length).fastForEach {
+                addUrlAnnotation(it.item, it.start, it.end)
+            }
+            text.getLinkAnnotations(start = 0, end = text.length).fastForEach { range ->
+                when (val item = range.item) {
+                    is LinkAnnotation.Url -> addLink(item, range.start, range.end)
+                    is LinkAnnotation.Clickable -> addLink(item, range.start, range.end)
+                }
             }
         }
     }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/RoundedCornerSpanPainter.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/RoundedCornerSpanPainter.kt
@@ -76,16 +76,15 @@ class RoundedCornerSpanPainter(
     override fun drawInstructionsFor(layoutResult: TextLayoutResult): SpanDrawInstructions {
         val text = layoutResult.layoutInput.text
         val annotations = text.getStringAnnotations(TAG, start = 0, end = text.length)
-        val linkAnnotations = text.getLinkAnnotations(start = 0, end = text.length)
 
         return SpanDrawInstructions {
             val cornerRadius = CornerRadius(cornerRadius.toPx())
 
-            fun drawForAnnotation(start: Int, end: Int, color: Color?) {
-                val backgroundColor = color!!
+            annotations.fastForEach { annotation ->
+                val backgroundColor = annotation.item.deserializeToColor()!!
                 val boxes = layoutResult.getBoundingBoxes(
-                    startOffset = start,
-                    endOffset = end,
+                    startOffset = annotation.start,
+                    endOffset = annotation.end,
                     flattenForFullParagraphs = true
                 )
                 boxes.fastForEachIndexed { index, box ->
@@ -119,13 +118,6 @@ class RoundedCornerSpanPainter(
                         )
                     }
                 }
-            }
-
-            annotations.fastForEach { annotation ->
-                drawForAnnotation(annotation.start, annotation.end, annotation.item.deserializeToColor())
-            }
-            linkAnnotations.fastForEach { annotation ->
-                drawForAnnotation(annotation.start, annotation.end, annotation.item.styles?.style?.background)
             }
         }
     }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/RoundedCornerSpanPainter.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/RoundedCornerSpanPainter.kt
@@ -73,7 +73,7 @@ class RoundedCornerSpanPainter(
         }
     }
 
-    override fun drawInstructionsFor(layoutResult: TextLayoutResult): SpanDrawInstructions {
+    override fun drawInstructionsFor(layoutResult: TextLayoutResult, color: Color?): SpanDrawInstructions {
         val text = layoutResult.layoutInput.text
         val annotations = text.getStringAnnotations(TAG, start = 0, end = text.length)
 

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/RoundedCornerSpanPainter.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/RoundedCornerSpanPainter.kt
@@ -61,8 +61,9 @@ class RoundedCornerSpanPainter(
         builder: AnnotatedString.Builder,
     ): LinkAnnotation {
         val defaultStyle = linkAnnotation.styles?.style
-        val updated = if (defaultStyle != null) decorate(defaultStyle, start, end, text, builder) else null
-
+        // return fast if background is not set
+        if (defaultStyle == null || defaultStyle.background.isUnspecified == true) return linkAnnotation
+        val updated = decorate(defaultStyle, start, end, text, builder)
         return if (linkAnnotation is LinkAnnotation.Url) {
             LinkAnnotation.Url(linkAnnotation.url, TextLinkStyles(updated), linkAnnotation.linkInteractionListener)
         } else if (linkAnnotation is LinkAnnotation.Clickable) {

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/RoundedCornerSpanPainter.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/RoundedCornerSpanPainter.kt
@@ -15,9 +15,9 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastForEachIndexed
 import com.mikepenz.markdown.compose.extendedspans.internal.deserializeToColor
-import com.mikepenz.markdown.compose.extendedspans.internal.fastForEach
-import com.mikepenz.markdown.compose.extendedspans.internal.fastForEachIndexed
 import com.mikepenz.markdown.compose.extendedspans.internal.serialize
 
 /**
@@ -41,17 +41,12 @@ class RoundedCornerSpanPainter(
         start: Int,
         end: Int,
         text: AnnotatedString,
-        builder: AnnotatedString.Builder
+        builder: AnnotatedString.Builder,
     ): SpanStyle {
         return if (span.background.isUnspecified) {
             span
         } else {
-            builder.addStringAnnotation(
-                TAG,
-                annotation = span.background.serialize(),
-                start = start,
-                end = end
-            )
+            builder.addStringAnnotation(TAG, annotation = span.background.serialize(), start = start, end = end)
             span.copy(background = Color.Unspecified)
         }
     }
@@ -107,7 +102,7 @@ class RoundedCornerSpanPainter(
 
     data class Stroke(
         val color: (background: Color) -> Color,
-        val width: TextUnit = 1.sp
+        val width: TextUnit = 1.sp,
     ) {
         constructor(color: Color, width: TextUnit = 1.sp) : this(
             color = { color },
@@ -117,7 +112,7 @@ class RoundedCornerSpanPainter(
 
     data class TextPaddingValues(
         val horizontal: TextUnit = 0.sp,
-        val vertical: TextUnit = 0.sp
+        val vertical: TextUnit = 0.sp,
     )
 
     companion object {

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/SquigglyUnderlineSpanPainter.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/SquigglyUnderlineSpanPainter.kt
@@ -1,8 +1,8 @@
+@file:Suppress("NAME_SHADOWING")
+
 // Copyright 2023, Saket Narayan
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/saket/extended-spans
-@file:Suppress("NAME_SHADOWING")
-
 package com.mikepenz.markdown.compose.extendedspans
 
 import androidx.compose.animation.core.LinearEasing
@@ -33,12 +33,11 @@ import androidx.compose.ui.text.style.TextDecoration.Companion.Underline
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.util.fastFirstOrNull
+import androidx.compose.ui.util.fastForEach
 import com.mikepenz.markdown.compose.extendedspans.internal.deserializeToColor
-import com.mikepenz.markdown.compose.extendedspans.internal.fastFirstOrNull
-import com.mikepenz.markdown.compose.extendedspans.internal.fastForEach
 import com.mikepenz.markdown.compose.extendedspans.internal.fastMapRange
 import com.mikepenz.markdown.compose.extendedspans.internal.serialize
-import kotlin.math.PI
 import kotlin.math.ceil
 import kotlin.math.sin
 import kotlin.time.Duration
@@ -79,7 +78,7 @@ class SquigglyUnderlineSpanPainter(
         start: Int,
         end: Int,
         text: AnnotatedString,
-        builder: AnnotatedString.Builder
+        builder: AnnotatedString.Builder,
     ): SpanStyle {
         val textDecoration = span.textDecoration
         return if (textDecoration == null || Underline !in textDecoration) {
@@ -91,12 +90,7 @@ class SquigglyUnderlineSpanPainter(
                 it.start <= start && it.end >= end && it.item.color.isSpecified
             }?.item?.color ?: Color.Unspecified
 
-            builder.addStringAnnotation(
-                TAG,
-                annotation = textColor.serialize(),
-                start = start,
-                end = end
-            )
+            builder.addStringAnnotation(TAG, annotation = textColor.serialize(), start = start, end = end)
             span.copy(textDecoration = if (LineThrough in textDecoration) LineThrough else None)
         }
     }
@@ -118,8 +112,7 @@ class SquigglyUnderlineSpanPainter(
                     startOffset = annotation.start,
                     endOffset = annotation.end
                 )
-                val textColor =
-                    annotation.item.deserializeToColor() ?: layoutResult.layoutInput.style.color
+                val textColor = annotation.item.deserializeToColor() ?: layoutResult.layoutInput.style.color
                 boxes.fastForEach { box ->
                     path.rewind()
                     path.buildSquigglesFor(box, density = this)
@@ -147,8 +140,7 @@ class SquigglyUnderlineSpanPainter(
         var pointX = lineStart
         fastMapRange(0, numOfPoints) { point ->
             val proportionOfWavelength = (pointX - lineStart) / wavelength.toPx()
-            val radiansX =
-                proportionOfWavelength * TWO_PI + (TWO_PI * animator.animationProgress.value)
+            val radiansX = proportionOfWavelength * TWO_PI + (TWO_PI * animator.animationProgress.value)
             val offsetY = lineBottom + (sin(radiansX) * amplitude.toPx())
 
             when (point) {
@@ -162,7 +154,7 @@ class SquigglyUnderlineSpanPainter(
     companion object {
         private const val TAG = "squiggly_underline_span"
         private const val SEGMENTS_PER_WAVELENGTH = 10
-        private const val TWO_PI = 2 * PI.toFloat()
+        private const val TWO_PI = 2 * Math.PI.toFloat()
     }
 }
 

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/SquigglyUnderlineSpanPainter.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/SquigglyUnderlineSpanPainter.kt
@@ -105,8 +105,12 @@ class SquigglyUnderlineSpanPainter(
         builder: AnnotatedString.Builder,
     ): LinkAnnotation {
         val defaultStyle = linkAnnotation.styles?.style
-        val updated = if (defaultStyle != null) decorate(defaultStyle, start, end, text, builder) else null
- 
+        val textDecoration = defaultStyle?.textDecoration
+
+        // return fast if no text decoration is set
+        if (defaultStyle == null || textDecoration == null || Underline !in textDecoration) return linkAnnotation
+
+        val updated = decorate(defaultStyle, start, end, text, builder)
         return if (linkAnnotation is LinkAnnotation.Url) {
             LinkAnnotation.Url(linkAnnotation.url, TextLinkStyles(updated), linkAnnotation.linkInteractionListener)
         } else if (linkAnnotation is LinkAnnotation.Clickable) {

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/SquigglyUnderlineSpanPainter.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/SquigglyUnderlineSpanPainter.kt
@@ -130,7 +130,7 @@ class SquigglyUnderlineSpanPainter(
         }
     }
 
-    override fun drawInstructionsFor(layoutResult: TextLayoutResult): SpanDrawInstructions {
+    override fun drawInstructionsFor(layoutResult: TextLayoutResult, color: Color?): SpanDrawInstructions {
         val text = layoutResult.layoutInput.text
         val annotations = text.getStringAnnotations(TAG, start = 0, end = text.length)
 
@@ -148,7 +148,7 @@ class SquigglyUnderlineSpanPainter(
                     endOffset = annotation.end
                 )
 
-                val textColor = annotation.item.deserializeToColor() ?: layoutResult.layoutInput.style.color
+                val textColor = annotation.item.deserializeToColor() ?: layoutResult.layoutInput.style.color.colorOrNull() ?: color ?: Color.Unspecified
                 boxes.fastForEach { box ->
                     path.rewind()
                     path.buildSquigglesFor(box, density = this)

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/internal/ColorSerializers.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/internal/ColorSerializers.kt
@@ -14,3 +14,7 @@ internal fun Color?.serialize(): String {
 internal fun String.deserializeToColor(): Color? {
     return if (this == "null") null else Color(this.toInt())
 }
+
+internal fun Color?.colorOrNull(): Color? {
+    return if (this == null || isUnspecified) null else this
+}

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/internal/ColorSerializers.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/internal/ColorSerializers.kt
@@ -7,10 +7,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.isUnspecified
 import androidx.compose.ui.graphics.toArgb
 
-fun Color?.serialize(): String {
+internal fun Color?.serialize(): String {
     return if (this == null || isUnspecified) "null" else "${toArgb()}"
 }
 
-fun String.deserializeToColor(): Color? {
+internal fun String.deserializeToColor(): Color? {
     return if (this == "null") null else Color(this.toInt())
 }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/internal/Lists.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/internal/Lists.kt
@@ -6,73 +6,11 @@ package com.mikepenz.markdown.compose.extendedspans.internal
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
-/**
- * Copied from [androidx](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:text/text/src/main/java/androidx/compose/ui/text/android/TempListUtils.kt;l=33;drc=b2e3d878411b7fb1147455b1a204cddb7bee1a1b).
- */
-@OptIn(ExperimentalContracts::class)
-internal inline fun <T> List<T>.fastForEach(action: (T) -> Unit) {
-    contract { callsInPlace(action) }
-    for (index in indices) {
-        val item = get(index)
-        action(item)
-    }
-}
-
-@OptIn(ExperimentalContracts::class)
-internal inline fun <T> List<T>.fastForEachIndexed(action: (index: Int, T) -> Unit) {
-    contract { callsInPlace(action) }
-    for (index in indices) {
-        val item = get(index)
-        action(index, item)
-    }
-}
-
-@OptIn(ExperimentalContracts::class)
-internal inline fun <T> List<T>.fastFirstOrNull(predicate: (T) -> Boolean): T? {
-    contract { callsInPlace(predicate) }
-    for (index in indices) {
-        val item = get(index)
-        if (predicate(item)) {
-            return item
-        }
-    }
-    return null
-}
-
-/**
- * Copied from [androidx](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:text/text/src/main/java/androidx/compose/ui/text/android/TempListUtils.kt;l=50;drc=b2e3d878411b7fb1147455b1a204cddb7bee1a1b).
- */
-@OptIn(ExperimentalContracts::class)
-internal inline fun <T, R> List<T>.fastMap(
-    transform: (T) -> R
-): List<R> {
-    contract { callsInPlace(transform) }
-    val destination = ArrayList<R>(/* initialCapacity = */ size)
-    fastForEach { item ->
-        destination.add(transform(item))
-    }
-    return destination
-}
-
-/**
- * Copied from [androidx](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/TempListUtils.kt;l=107;drc=ceaa7640c065146360515e598a3d09f6f66553dd).
- */
-@Suppress("BanInlineOptIn") // Treat Kotlin Contracts as non-experimental.
-@OptIn(ExperimentalContracts::class)
-internal inline fun <T, R> List<T>.fastFold(initial: R, operation: (acc: R, T) -> R): R {
-    contract { callsInPlace(operation) }
-    var accumulator = initial
-    fastForEach { e ->
-        accumulator = operation(accumulator, e)
-    }
-    return accumulator
-}
-
 @OptIn(ExperimentalContracts::class)
 internal inline fun <R> fastMapRange(
     start: Int,
     end: Int,
-    transform: (Int) -> R
+    transform: (Int) -> R,
 ): List<R> {
     contract { callsInPlace(transform) }
     val destination = ArrayList<R>(/* initialCapacity = */ end - start + 1)

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownTypography.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownTypography.kt
@@ -1,6 +1,7 @@
 package com.mikepenz.markdown.model
 
 import androidx.compose.runtime.Immutable
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.TextStyle
 
 interface MarkdownTypography {
@@ -18,7 +19,10 @@ interface MarkdownTypography {
     val ordered: TextStyle
     val bullet: TextStyle
     val list: TextStyle
+
+    @Deprecated("Use textLink instead", ReplaceWith("textLink"))
     val link: TextStyle
+    val textLink: TextLinkStyles
 }
 
 @Immutable
@@ -37,5 +41,7 @@ class DefaultMarkdownTypography(
     override val ordered: TextStyle,
     override val bullet: TextStyle,
     override val list: TextStyle,
+    @Deprecated("Use textLink instead", replaceWith = ReplaceWith("textLink"))
     override val link: TextStyle,
+    override val textLink: TextLinkStyles,
 ) : MarkdownTypography

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
@@ -9,11 +9,6 @@ import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.getTextInNode
 
 /**
- * Tag used to indicate an url for inline content. Required for click handling.
- */
-const val MARKDOWN_TAG_URL = "MARKDOWN_URL"
-
-/**
  * Tag used to indicate an image url for inline content. Required for rendering.
  */
 const val MARKDOWN_TAG_IMAGE_URL = "MARKDOWN_IMAGE_URL"
@@ -59,14 +54,6 @@ fun ASTNode.getUnescapedTextInNode(allFileText: CharSequence): String {
         processEscapes = true
     )
 }
-
-/**
- * Extension property to get the `SpanStyle` for link text.
- * This style is defined by the `link` typography and the current markdown colors.
- */
-val MarkdownTypography.linkTextSpanStyle: SpanStyle
-    @Composable
-    get() = link.copy(color = LocalMarkdownColors.current.linkText).toSpanStyle()
 
 /**
  * Extension property to get the `SpanStyle` for inline code text.


### PR DESCRIPTION
Refactor library to use the new `withLink` from Compose 1.7 to handle links within annotated strings
Rework extended-spans to support these links
Introduce new `textLink` typography spec so links can be fully themed for all the different interaction states

Example

```kotlin
typography = markdownTypography(
        textLink = TextLinkStyles(
            style = TextStyle(color = Color.Red, textDecoration = TextDecoration.Underline).toSpanStyle(),
            hoveredStyle = TextStyle(color = Color.Blue, textDecoration = TextDecoration.Underline).toSpanStyle(),
            pressedStyle = TextStyle(color = Color.Green, textDecoration = TextDecoration.Underline).toSpanStyle(),
        )
    ),
```