### PR TITLE
Enhance backwards compatiblity

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownImageState.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownImageState.kt
@@ -1,16 +1,33 @@
 package com.mikepenz.markdown.model
 
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.toIntSize
+import androidx.compose.ui.unit.toSize
 
 interface MarkdownImageState {
     val density: Density
     val containerSize: Size
     val intrinsicImageSize: Size
-    fun updateContainerSize(size: Size)
-    fun updateImageSize(size: Size)
+
+    @Deprecated("Use updateContainerSize instead", ReplaceWith("updateContainerSize(size)"))
+    fun setContainerSize(intSize: IntSize)
+
+    @Deprecated("Use updateImageSize instead", ReplaceWith("updateImageSize(size)"))
+    fun setImageSize(size: Size)
+
+    @Suppress("DEPRECATION")
+    fun updateContainerSize(size: Size) = setContainerSize(size.toIntSize())
+
+    @Suppress("DEPRECATION")
+    fun updateImageSize(size: Size) = setImageSize(size)
 }
 
 internal class MarkdownImageStateImpl(override val density: Density) : MarkdownImageState {
@@ -18,6 +35,12 @@ internal class MarkdownImageStateImpl(override val density: Density) : MarkdownI
     override var containerSize by mutableStateOf(Size.Unspecified)
 
     override var intrinsicImageSize by mutableStateOf(Size.Unspecified)
+
+    @Deprecated("Use updateContainerSize instead", replaceWith = ReplaceWith("updateContainerSize(size)"))
+    override fun setContainerSize(intSize: IntSize) = updateContainerSize(intSize.toSize())
+
+    @Deprecated("Use updateImageSize instead", replaceWith = ReplaceWith("updateImageSize(size)"))
+    override fun setImageSize(size: Size) = updateImageSize(size)
 
     override fun updateContainerSize(size: Size) {
         containerSize = size


### PR DESCRIPTION
- retain legacy function's for `MarkdownImageState` to retain backwards compatibility