### PR TITLE
Improve accessibility for MarkdownHeader.

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHeader.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownHeader.kt
@@ -1,6 +1,9 @@
 package com.mikepenz.markdown.compose.elements
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import org.intellij.markdown.IElementType
 import org.intellij.markdown.MarkdownTokenTypes
@@ -12,4 +15,12 @@ fun MarkdownHeader(
     node: ASTNode,
     style: TextStyle,
     contentChildType: IElementType = MarkdownTokenTypes.ATX_CONTENT,
-) = MarkdownText(content = content, node = node, style = style, contentChildType = contentChildType)
+) = MarkdownText(
+    modifier = Modifier.semantics {
+        heading()
+    },
+    content = content,
+    node = node,
+    style = style,
+    contentChildType = contentChildType,
+)


### PR DESCRIPTION
+ TalkBack will read out e.g. "This is an H3, heading" instead of "This is an H3".