### PR TITLE
Add depth to `BulletHandler`

### DIFF
--- a/multiplatform-markdown-renderer/api/android/multiplatform-markdown-renderer.api
+++ b/multiplatform-markdown-renderer/api/android/multiplatform-markdown-renderer.api
@@ -329,7 +329,7 @@ public final class com/mikepenz/markdown/compose/extendedspans/internal/TextLink
 }
 
 public abstract interface class com/mikepenz/markdown/model/BulletHandler {
-	public abstract fun transform (Lorg/intellij/markdown/IElementType;Ljava/lang/CharSequence;I)Ljava/lang/String;
+	public abstract fun transform (Lorg/intellij/markdown/IElementType;Ljava/lang/CharSequence;II)Ljava/lang/String;
 }
 
 public final class com/mikepenz/markdown/model/DefaultMarkdownAnimation : com/mikepenz/markdown/model/MarkdownAnimations {

--- a/multiplatform-markdown-renderer/api/jvm/multiplatform-markdown-renderer.api
+++ b/multiplatform-markdown-renderer/api/jvm/multiplatform-markdown-renderer.api
@@ -329,7 +329,7 @@ public final class com/mikepenz/markdown/compose/extendedspans/internal/TextLink
 }
 
 public abstract interface class com/mikepenz/markdown/model/BulletHandler {
-	public abstract fun transform (Lorg/intellij/markdown/IElementType;Ljava/lang/CharSequence;I)Ljava/lang/String;
+	public abstract fun transform (Lorg/intellij/markdown/IElementType;Ljava/lang/CharSequence;II)Ljava/lang/String;
 }
 
 public final class com/mikepenz/markdown/model/DefaultMarkdownAnimation : com/mikepenz/markdown/model/MarkdownAnimations {

--- a/multiplatform-markdown-renderer/api/multiplatform-markdown-renderer.klib.api
+++ b/multiplatform-markdown-renderer/api/multiplatform-markdown-renderer.klib.api
@@ -11,7 +11,7 @@ abstract fun interface com.mikepenz.markdown.compose.extendedspans/SpanDrawInstr
 }
 
 abstract fun interface com.mikepenz.markdown.model/BulletHandler { // com.mikepenz.markdown.model/BulletHandler|null[0]
-    abstract fun transform(org.intellij.markdown/IElementType, kotlin/CharSequence?, kotlin/Int): kotlin/String // com.mikepenz.markdown.model/BulletHandler.transform|transform(org.intellij.markdown.IElementType;kotlin.CharSequence?;kotlin.Int){}[0]
+    abstract fun transform(org.intellij.markdown/IElementType, kotlin/CharSequence?, kotlin/Int, kotlin/Int): kotlin/String // com.mikepenz.markdown.model/BulletHandler.transform|transform(org.intellij.markdown.IElementType;kotlin.CharSequence?;kotlin.Int;kotlin.Int){}[0]
 }
 
 abstract interface com.mikepenz.markdown.annotator/AnnotatorSettings { // com.mikepenz.markdown.annotator/AnnotatorSettings|null[0]

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/ComposeLocal.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/ComposeLocal.kt
@@ -21,14 +21,14 @@ import com.mikepenz.markdown.model.ReferenceLinkHandler
  * The CompositionLocal to provide functionality related to transforming the bullet of an ordered list
  */
 val LocalBulletListHandler = staticCompositionLocalOf {
-    return@staticCompositionLocalOf BulletHandler { _, _, _ -> "• " }
+    return@staticCompositionLocalOf BulletHandler { _, _, _, _ -> "• " }
 }
 
 /**
  * The CompositionLocal to provide functionality related to transforming the bullet of an ordered list
  */
 val LocalOrderedListHandler = staticCompositionLocalOf {
-    return@staticCompositionLocalOf BulletHandler { _, _, index -> "${index + 1}. " }
+    return@staticCompositionLocalOf BulletHandler { _, _, index, _ -> "${index + 1}. " }
 }
 
 /**

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownList.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownList.kt
@@ -110,7 +110,8 @@ fun MarkdownOrderedList(
             text = orderedListHandler.transform(
                 LIST_NUMBER,
                 child?.getUnescapedTextInNode(content),
-                index
+                index,
+                level
             ),
             style = style,
             color = LocalMarkdownColors.current.text,
@@ -132,7 +133,8 @@ fun MarkdownBulletList(
             bulletHandler.transform(
                 LIST_BULLET,
                 child?.getUnescapedTextInNode(content),
-                index
+                index,
+                level
             ),
             style = style,
             color = LocalMarkdownColors.current.text,

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/BulletHandler.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/BulletHandler.kt
@@ -4,5 +4,5 @@ import org.intellij.markdown.IElementType
 
 /** An interface of providing use case specific un/ordered list handling.*/
 fun interface BulletHandler {
-    fun transform(type: IElementType, bullet: CharSequence?, index: Int): String
+    fun transform(type: IElementType, bullet: CharSequence?, index: Int, depth: Int): String
 }


### PR DESCRIPTION
Allows for customizing the bullet based on the depth. Example usage:

```kt
Markdown(
    MARKDOWN,
    components = markdownComponents(
        unorderedList = { ul ->
            val markers = listOf("•", "◦", "▸", "▹")

            CompositionLocalProvider(LocalBulletListHandler provides { _, _, _, level -> "${markers[level % markers.size]} " }) {
                MarkdownBulletList(ul.content, ul.node, style = ul.typography.bullet)
            }
        }
    )
)
```
![image](https://github.com/user-attachments/assets/2be96fc5-47ab-4260-89f9-62dc19b0ee64)
