### PR TITLE
Remove nested handling of elements in `Markdown` and `LazyMarkdown`

### DIFF
--- a/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/Markdown.kt
+++ b/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/Markdown.kt
@@ -69,11 +69,11 @@ fun Markdown(
     components: MarkdownComponents = markdownComponents(checkbox = { MarkdownCheckBox(it.content, it.node, it.typography.text) }),
     animations: MarkdownAnimations = markdownAnimations(),
     referenceLinkHandler: ReferenceLinkHandler = ReferenceLinkHandlerImpl(),
-    loading: @Composable (modifier: Modifier) -> Unit = { Box(modifier) {} },
+    loading: @Composable (modifier: Modifier) -> Unit = { Box(modifier) },
     success: @Composable (state: State.Success, components: MarkdownComponents, modifier: Modifier) -> Unit = { state, components, modifier ->
         MarkdownSuccess(state = state, components = components, modifier = modifier)
     },
-    error: @Composable (modifier: Modifier) -> Unit = { Box(modifier) {} },
+    error: @Composable (modifier: Modifier) -> Unit = { Box(modifier) },
 ) = com.mikepenz.markdown.compose.Markdown(
     content = content,
     colors = colors,
@@ -125,11 +125,11 @@ fun Markdown(
     extendedSpans: MarkdownExtendedSpans = markdownExtendedSpans(),
     components: MarkdownComponents = markdownComponents(checkbox = { MarkdownCheckBox(it.content, it.node, it.typography.text) }),
     animations: MarkdownAnimations = markdownAnimations(),
-    loading: @Composable (modifier: Modifier) -> Unit = { Box(modifier) {} },
+    loading: @Composable (modifier: Modifier) -> Unit = { Box(modifier) },
     success: @Composable (state: State.Success, components: MarkdownComponents, modifier: Modifier) -> Unit = { state, components, modifier ->
         MarkdownSuccess(state = state, components = components, modifier = modifier)
     },
-    error: @Composable (modifier: Modifier) -> Unit = { Box(modifier) {} },
+    error: @Composable (modifier: Modifier) -> Unit = { Box(modifier) },
 ) = com.mikepenz.markdown.compose.Markdown(
     state = state,
     colors = colors,

--- a/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/Markdown.kt
+++ b/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/Markdown.kt
@@ -69,11 +69,11 @@ fun Markdown(
     components: MarkdownComponents = markdownComponents(checkbox = { MarkdownCheckBox(it.content, it.node, it.typography.text) }),
     animations: MarkdownAnimations = markdownAnimations(),
     referenceLinkHandler: ReferenceLinkHandler = ReferenceLinkHandlerImpl(),
-    loading: @Composable (modifier: Modifier) -> Unit = { Box(modifier) {} },
+    loading: @Composable (modifier: Modifier) -> Unit = { Box(modifier) },
     success: @Composable (state: State.Success, components: MarkdownComponents, modifier: Modifier) -> Unit = { state, components, modifier ->
         MarkdownSuccess(state = state, components = components, modifier = modifier)
     },
-    error: @Composable (modifier: Modifier) -> Unit = { Box(modifier) {} },
+    error: @Composable (modifier: Modifier) -> Unit = { Box(modifier) },
 ) = com.mikepenz.markdown.compose.Markdown(
     content = content,
     colors = colors,
@@ -125,11 +125,11 @@ fun Markdown(
     extendedSpans: MarkdownExtendedSpans = markdownExtendedSpans(),
     components: MarkdownComponents = markdownComponents(checkbox = { MarkdownCheckBox(it.content, it.node, it.typography.text) }),
     animations: MarkdownAnimations = markdownAnimations(),
-    loading: @Composable (modifier: Modifier) -> Unit = { Box(modifier) {} },
+    loading: @Composable (modifier: Modifier) -> Unit = { Box(modifier) },
     success: @Composable (state: State.Success, components: MarkdownComponents, modifier: Modifier) -> Unit = { state, components, modifier ->
         MarkdownSuccess(state = state, components = components, modifier = modifier)
     },
-    error: @Composable (modifier: Modifier) -> Unit = { Box(modifier) {} },
+    error: @Composable (modifier: Modifier) -> Unit = { Box(modifier) },
 ) = com.mikepenz.markdown.compose.Markdown(
     state = state,
     colors = colors,

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/LazyMarkdown.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/LazyMarkdown.kt
@@ -29,11 +29,7 @@ fun LazyMarkdownSuccess(
         contentPadding = contentPadding,
     ) {
         items(state.node.children) { node ->
-            if (!handleElement(node, components, state.content, skipLinkDefinition = state.linksLookedUp)) {
-                node.children.forEach { child ->
-                    handleElement(child, components, state.content, skipLinkDefinition = state.linksLookedUp)
-                }
-            }
+            handleElement(node, components, state.content, skipLinkDefinition = state.linksLookedUp)
         }
     }
 }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
@@ -71,11 +71,11 @@ fun Markdown(
     components: MarkdownComponents = markdownComponents(),
     animations: MarkdownAnimations = markdownAnimations(),
     referenceLinkHandler: ReferenceLinkHandler = ReferenceLinkHandlerImpl(),
-    loading: @Composable (modifier: Modifier) -> Unit = { Box(modifier) {} },
+    loading: @Composable (modifier: Modifier) -> Unit = { Box(modifier) },
     success: @Composable (state: State.Success, components: MarkdownComponents, modifier: Modifier) -> Unit = { state, components, modifier ->
         MarkdownSuccess(state = state, components = components, modifier = modifier)
     },
-    error: @Composable (modifier: Modifier) -> Unit = { Box(modifier) {} },
+    error: @Composable (modifier: Modifier) -> Unit = { Box(modifier) },
 ) {
     val state = rememberMarkdownState(
         content = content,
@@ -133,11 +133,11 @@ fun Markdown(
     extendedSpans: MarkdownExtendedSpans = markdownExtendedSpans(),
     components: MarkdownComponents = markdownComponents(),
     animations: MarkdownAnimations = markdownAnimations(),
-    loading: @Composable (modifier: Modifier) -> Unit = { Box(modifier) {} },
+    loading: @Composable (modifier: Modifier) -> Unit = { Box(modifier) },
     success: @Composable (state: State.Success, components: MarkdownComponents, modifier: Modifier) -> Unit = { state, components, modifier ->
         MarkdownSuccess(state = state, components = components, modifier = modifier)
     },
-    error: @Composable (modifier: Modifier) -> Unit = { Box(modifier) {} },
+    error: @Composable (modifier: Modifier) -> Unit = { Box(modifier) },
 ) {
     val markdownState by state.state.collectAsState()
     CompositionLocalProvider(

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt
@@ -175,11 +175,7 @@ fun MarkdownSuccess(
 ) {
     Column(modifier) {
         state.node.children.forEach { node ->
-            if (!handleElement(node, components, state.content, skipLinkDefinition = state.linksLookedUp)) {
-                node.children.forEach { child ->
-                    handleElement(child, components, state.content, skipLinkDefinition = state.linksLookedUp)
-                }
-            }
+            handleElement(node, components, state.content, skipLinkDefinition = state.linksLookedUp)
         }
     }
 }


### PR DESCRIPTION
There is a logical duplication in handling nested elements between:

https://github.com/mikepenz/multiplatform-markdown-renderer/blob/d7c9c0dad54931ae42c6eec31fb041db8b3be460/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/MarkdownExtension.kt#L76-L79

https://github.com/mikepenz/multiplatform-markdown-renderer/blob/d7c9c0dad54931ae42c6eec31fb041db8b3be460/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/Markdown.kt#L178-L181

