### PR TITLE
Fix publish step condition in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             gradle-${{ runner.os }}-
 
       - name: Publish the macOS artifacts
-        if: matrix.os == 'macos-14'
+        if: matrix.os == 'macos-latest'
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.NEXUS_PASSWORD }}


### PR DESCRIPTION
The runner was changed in https://github.com/mikepenz/multiplatform-markdown-renderer/commit/a2fb3c1c52129aa136e66c2b2874f9761e51419c but this condition wasn't updated, so now publications aren't running when a release is created.

Also seems like the `strategy` / `matrix` part could be removed entirely from the script now, with cross-compilation. You could also use a Linux-based runner instead of macOS if you prefer.