### PR TITLE
Fix VM example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ val markdownFlow = parseMarkdownFlow("# Markdown")
     .stateIn(lifecycleScope, SharingStarted.Eagerly, State.Loading())
 
 // In the Composable use the flow
-val state by markdownFlow.collectAsStateWithLifecycle(State.Loading())
+val state by markdownFlow.collectAsStateWithLifecycle()
 Markdown(state)
 ```
 


### PR DESCRIPTION
Collecting with `Flow.collectAsStateWithLifecycle` will always first emit the initial value passed in, in this case, momentarily showing `State.Loading` again every time the collection restarts.

Using `StateFlow.collectAsStateWithLifecycle` instead avoids this problem, as its initial value will be the current `value` of the `StateFlow`, which can already be `State.Success` if the parsing was completed earlier.