### PR TITLE
Make markdown parsing `immediate` if `LocalInspectionMode` is true

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownState.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownState.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalInspectionMode
 import com.mikepenz.markdown.utils.lookupLinkDefinition
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,7 +35,7 @@ fun rememberMarkdownState(
     flavour: MarkdownFlavourDescriptor = GFMFlavourDescriptor(),
     parser: MarkdownParser = MarkdownParser(flavour),
     referenceLinkHandler: ReferenceLinkHandler = ReferenceLinkHandlerImpl(),
-    immediate: Boolean = false,
+    immediate: Boolean = LocalInspectionMode.current,
 ): MarkdownState {
     val input = Input(
         content = content,

--- a/sample/android/src/screenshotTest/kotlin/com/mikepenz/markdown/ui/m2/util/Helper.kt
+++ b/sample/android/src/screenshotTest/kotlin/com/mikepenz/markdown/ui/m2/util/Helper.kt
@@ -8,5 +8,5 @@ import com.mikepenz.markdown.ui.m2.theme.SampleTheme
 
 @Composable
 fun TestMarkdown(content: String) = SampleTheme(isSystemInDarkTheme()) {
-    Markdown(rememberMarkdownState(content, immediate = true))
+    Markdown(rememberMarkdownState(content))
 }

--- a/sample/android/src/screenshotTest/kotlin/com/mikepenz/markdown/ui/m3/util/Helper.kt
+++ b/sample/android/src/screenshotTest/kotlin/com/mikepenz/markdown/ui/m3/util/Helper.kt
@@ -8,5 +8,5 @@ import com.mikepenz.markdown.ui.m3.theme.SampleTheme
 
 @Composable
 fun TestMarkdown(content: String) = SampleTheme(isSystemInDarkTheme()) {
-    Markdown(rememberMarkdownState(content, immediate = true))
+    Markdown(rememberMarkdownState(content))
 }


### PR DESCRIPTION
- make `rememberMarkdownState` `immediate` if we are in `LocalInspectionMode` (e.g. preview)
  - FIX https://github.com/mikepenz/multiplatform-markdown-renderer/issues/385