### PR TITLE
fix: Small images rendering

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
@@ -145,7 +145,7 @@ fun MarkdownText(
                 if (placeholderState.animate) animations.animateTextSize(it) else it
             },
         style = style,
-        inlineContent = remember {
+        inlineContent = remember(inlineContent.inlineContent, placeholderState, transformer) {
             inlineContent.inlineContent + mapOf(
                 MARKDOWN_TAG_IMAGE_URL to createImageInlineTextContent(
                     placeholderState,


### PR DESCRIPTION
After upgrading from 0.33.0 to 0.34.0 the images became very small. The reason is that inlineContent in MarkdownText is remembered, but does not take into account the keys that change