### PR TITLE
Fix parameter name of MarkdownListItems in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Another example to of a custom component is changing the rendering of an unorder
 // Define a custom component for rendering unordered list items in Markdown
 val customUnorderedListComponent: MarkdownComponent = {
     // Use the MarkdownListItems composable to render the list items
-    MarkdownListItems(it.content, it.node, level = 0) { startNumber, index, child ->
+    MarkdownListItems(it.content, it.node, depth = 0) { startNumber, index, child ->
         // Render an icon for the bullet point with a green tint
         Icon(
             imageVector = icon,


### PR DESCRIPTION
## Description
- Fix parameter name `level` -> `depth` of `MarkdownListItems`.

## Type of change
- [x] Documentation update

## Checklist:
- [x] I have made corresponding changes to the documentation