### PR TITLE
Improve accessibility of ordered and unordered list items.

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownList.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownList.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import com.mikepenz.markdown.compose.LocalBulletListHandler
 import com.mikepenz.markdown.compose.LocalMarkdownComponents
@@ -112,6 +113,7 @@ private fun MarkdownListItem(
 
     Row(
         modifier = Modifier
+            .semantics(mergeDescendants = true) {}
             .fillMaxWidth()
             .padding(top = padding.listItemTop, bottom = padding.listItemBottom)
     ) {


### PR DESCRIPTION
+ TalkBack will read out e.g. "One, lorem ipsum" instead of "One" for the ordered list item prefix number and then "lorem ipsum" on its own.
+ TalkBack selects both the item prefix and the text as one element:
  <img width="270" height="600" alt="sample" src="https://github.com/user-attachments/assets/78d8dc06-eb19-4d33-9e9a-fd996236964f" />
+ Does not apply to list items which prepend a checkbox.

---

Relates #417, #318
