### PR TITLE
Compose 1.10.0 | Kotlin 2.3.0

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,10 @@
 ### Upgrade Notes
 
+#### Version 0.39.0
+
+- **Note**: The `highlights` library in v1.1.0 seems to be compiled with Java 21
+- **Note**: Some dependencies start to require minSDK: 23 (compared to the minSDK of 21 from before)
+
 #### Version 0.38.0
 
 - **Breaking Change**: Removes prior deprecated APIs and functionality (`PlaceholderConfig.animate`)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
     alias(baseLibs.plugins.mavenPublish) apply false
     alias(baseLibs.plugins.binaryCompatiblityValidator) apply false
     alias(baseLibs.plugins.versionCatalogUpdate) apply false
-    alias(baseLibs.plugins.compatPatrouille) apply false
+    alias(baseLibs.plugins.tapmoc) apply false
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
-androidx-activityCompose = "1.10.1"
+androidx-activityCompose = "1.12.2"
 coil = "3.3.0"
 coil2 = "2.7.0"
 markdown = "0.7.3"
-ktor = "3.2.3"
-highlights = "1.0.0"
+ktor = "3.3.3"
+highlights = "1.1.0"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }

--- a/sample/android/gradle.properties
+++ b/sample/android/gradle.properties
@@ -1,1 +1,2 @@
 com.mikepenz.binary-compatibility-validator.enabled=false
+com.mikepenz.android.minSdk=23

--- a/sample/desktop/build.gradle.kts
+++ b/sample/desktop/build.gradle.kts
@@ -36,9 +36,6 @@ compose.resources {
 }
 
 aboutLibraries {
-    android {
-        registerAndroidTasks = false
-    }
     export {
         exportVariant = "jvmMain"
         outputPath = file("src/commonMain/composeResources/files/aboutlibraries.json")

--- a/sample/desktop/gradle.properties
+++ b/sample/desktop/gradle.properties
@@ -1,2 +1,3 @@
 com.mikepenz.binary-compatibility-validator.enabled=false
 com.mikepenz.hotreload.enabled=true
+com.mikepenz.java.version=21

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,7 +28,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.9.0")
+            from("com.mikepenz:version-catalog:0.10.1")
         }
     }
 }


### PR DESCRIPTION
## Description


Update dependencies and configuration
- Compose 1.10.0
- Kotlin 2.3.0
- Bump androidx.activityCompose to 1.12.2
- Update ktor to 3.3.3 and highlights to 1.1.0
- Set (for sample) minSdk to 23 and Java version to 21
- Remove deprecated Android tasks in build.gradle.kts
- Update version catalog to 0.10.1
- Add migration notes for new version

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build configuration change
- [ ] Other (please describe):

