### PR TITLE
Fix markdown display within `[]`

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/annotator/AnnotatedStringKtx.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/annotator/AnnotatedStringKtx.kt
@@ -183,8 +183,12 @@ fun AnnotatedString.Builder.appendMarkdownReference(
             buildMarkdownAnnotatedString(content, linkText.mapAutoLinkToType(), annotatorSettings)
         }
     } else {
-        // if no reference is found, reference links are just rendered as normal text.
-        append(node.getUnescapedTextInNode(content))
+        // if no reference is found, reference links are rendered as their individual components
+        val linkText = node.findChildOfType(MarkdownElementTypes.LINK_TEXT)
+        if (linkText != null) {
+            buildMarkdownAnnotatedString(content, linkText, annotatorSettings)
+        }
+        buildMarkdownAnnotatedString(content, labelNode, annotatorSettings)
     }
 }
 


### PR DESCRIPTION
## Description

Fix markdown display within `[]`

Fixes # (issue)

- https://github.com/mikepenz/multiplatform-markdown-renderer/issues/492

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build configuration change
- [ ] Other (please describe):

