### PR TITLE
fix(image): render reference-style images via referenceLinkHandler (#494)

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/annotator/AnnotatedStringKtx.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/annotator/AnnotatedStringKtx.kt
@@ -18,6 +18,7 @@ import com.mikepenz.markdown.model.markdownAnnotator
 import com.mikepenz.markdown.utils.MARKDOWN_TAG_IMAGE_URL
 import com.mikepenz.markdown.utils.findChildOfTypeRecursive
 import com.mikepenz.markdown.utils.getUnescapedTextInNode
+import com.mikepenz.markdown.utils.resolveImageLink
 import com.mikepenz.markdown.utils.innerList
 import com.mikepenz.markdown.utils.mapAutoLinkToType
 import org.intellij.markdown.MarkdownElementTypes
@@ -260,8 +261,7 @@ fun AnnotatedString.Builder.buildMarkdownAnnotatedString(
                     // Element types
                     MarkdownElementTypes.PARAGRAPH -> buildMarkdownAnnotatedString(content = content, node = child, annotatorSettings = annotatorSettings)
 
-                    MarkdownElementTypes.IMAGE -> child.findChildOfTypeRecursive(MarkdownElementTypes.LINK_DESTINATION)?.let {
-                        val imageUrl = it.getUnescapedTextInNode(content)
+                    MarkdownElementTypes.IMAGE -> child.resolveImageLink(content, annotatorSettings.referenceLinkHandler)?.let { imageUrl ->
                         appendInlineContent("${MARKDOWN_TAG_IMAGE_URL}_$imageUrl", imageUrl)
                     }
 

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownImage.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownImage.kt
@@ -3,15 +3,14 @@ package com.mikepenz.markdown.compose.elements
 import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
 import com.mikepenz.markdown.compose.LocalImageTransformer
-import com.mikepenz.markdown.utils.findChildOfTypeRecursive
-import com.mikepenz.markdown.utils.getUnescapedTextInNode
-import org.intellij.markdown.MarkdownElementTypes
+import com.mikepenz.markdown.compose.LocalReferenceLinkHandler
+import com.mikepenz.markdown.utils.resolveImageLink
 import org.intellij.markdown.ast.ASTNode
 
 @Composable
 fun MarkdownImage(content: String, node: ASTNode) {
 
-    val link = node.findChildOfTypeRecursive(MarkdownElementTypes.LINK_DESTINATION)?.getUnescapedTextInNode(content) ?: return
+    val link = node.resolveImageLink(content, LocalReferenceLinkHandler.current) ?: return
 
     LocalImageTransformer.current.transform(link)?.let { imageData ->
         Image(

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.SpanStyle
 import com.mikepenz.markdown.compose.LocalMarkdownColors
 import com.mikepenz.markdown.model.MarkdownTypography
+import com.mikepenz.markdown.model.ReferenceLinkHandler
 import org.intellij.markdown.IElementType
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
@@ -18,6 +19,28 @@ import org.intellij.markdown.flavours.gfm.GFMTokenTypes
  * Tag used to indicate an image url for inline content. Required for rendering.
  */
 const val MARKDOWN_TAG_IMAGE_URL = "MARKDOWN_IMAGE_URL"
+
+/**
+ * Resolve the destination URL for an `IMAGE` node. Falls back to looking up
+ * a `FULL_REFERENCE_LINK` / `SHORT_REFERENCE_LINK` descendant's `LINK_LABEL`
+ * via the supplied [referenceLinkHandler] when no inline `LINK_DESTINATION`
+ * is present (i.e. for reference-style images like `![alt][id]`).
+ */
+internal fun ASTNode.resolveImageLink(
+    content: String,
+    referenceLinkHandler: ReferenceLinkHandler?,
+): String? {
+    findChildOfTypeRecursive(MarkdownElementTypes.LINK_DESTINATION)?.let {
+        return it.getUnescapedTextInNode(content)
+    }
+    val refNode = findChildOfTypeRecursive(MarkdownElementTypes.FULL_REFERENCE_LINK)
+        ?: findChildOfTypeRecursive(MarkdownElementTypes.SHORT_REFERENCE_LINK)
+        ?: return null
+    val label = refNode.findChildOfType(MarkdownElementTypes.LINK_LABEL)
+        ?.getUnescapedTextInNode(content)
+        ?: return null
+    return referenceLinkHandler?.find(label)?.takeIf { it.isNotEmpty() }
+}
 
 /**
  * Find a child node recursive


### PR DESCRIPTION
## Summary
- Reference-style images (`![alt][id]`) parse with a `FULL_REFERENCE_LINK` / `SHORT_REFERENCE_LINK` child instead of an inline `LINK_DESTINATION`. Both the annotator and `MarkdownImage` were doing only a `findChildOfTypeRecursive(LINK_DESTINATION)` lookup, so these images silently failed to render.
- Add `ASTNode.resolveImageLink(content, referenceLinkHandler)` that falls back to resolving the `LINK_LABEL` against the populated `ReferenceLinkHandler`.
- Use it from the annotator's `IMAGE` branch and from `MarkdownImage`.

Closes #494

## Test plan
- [ ] Manual: render a doc containing `![Alt text][id]` plus matching `[id]: https://...` definition; image appears.
- [ ] Manual: short-reference form `![id]` with matching definition renders.
- [ ] Manual: regular inline images (`![alt](url)`) still render.
- [ ] Manual: reference image with unknown label gracefully falls back (no crash, no render).