### PR TITLE
feat(image): add hover tooltip showing image alt text

### DIFF
--- a/multiplatform-markdown-renderer/api/jvm/multiplatform-markdown-renderer.api
+++ b/multiplatform-markdown-renderer/api/jvm/multiplatform-markdown-renderer.api
@@ -373,11 +373,13 @@ public final class com/mikepenz/markdown/model/DefaultMarkdownAnnotator : com/mi
 public final class com/mikepenz/markdown/model/DefaultMarkdownAnnotatorConfig : com/mikepenz/markdown/model/MarkdownAnnotatorConfig {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (ZZ)V
-	public synthetic fun <init> (ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZJ)V
+	public synthetic fun <init> (ZZZJILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getEolAsNewLine ()Z
+	public fun getImageAltTooltipHoverDelayMs ()J
 	public fun getInlineImageAsBlock ()Z
+	public fun getShowImageAltTooltip ()Z
 	public fun hashCode ()I
 }
 
@@ -551,7 +553,9 @@ public abstract interface class com/mikepenz/markdown/model/MarkdownAnnotatorCon
 	public static final field BLOCK_FALLBACK_LINE_MULTIPLIER F
 	public static final field Companion Lcom/mikepenz/markdown/model/MarkdownAnnotatorConfig$Companion;
 	public abstract fun getEolAsNewLine ()Z
+	public fun getImageAltTooltipHoverDelayMs ()J
 	public fun getInlineImageAsBlock ()Z
+	public fun getShowImageAltTooltip ()Z
 }
 
 public final class com/mikepenz/markdown/model/MarkdownAnnotatorConfig$Companion {
@@ -559,12 +563,14 @@ public final class com/mikepenz/markdown/model/MarkdownAnnotatorConfig$Companion
 }
 
 public final class com/mikepenz/markdown/model/MarkdownAnnotatorConfig$DefaultImpls {
+	public static fun getImageAltTooltipHoverDelayMs (Lcom/mikepenz/markdown/model/MarkdownAnnotatorConfig;)J
 	public static fun getInlineImageAsBlock (Lcom/mikepenz/markdown/model/MarkdownAnnotatorConfig;)Z
+	public static fun getShowImageAltTooltip (Lcom/mikepenz/markdown/model/MarkdownAnnotatorConfig;)Z
 }
 
 public final class com/mikepenz/markdown/model/MarkdownAnnotatorConfigKt {
-	public static final fun markdownAnnotatorConfig (ZZ)Lcom/mikepenz/markdown/model/MarkdownAnnotatorConfig;
-	public static synthetic fun markdownAnnotatorConfig$default (ZZILjava/lang/Object;)Lcom/mikepenz/markdown/model/MarkdownAnnotatorConfig;
+	public static final fun markdownAnnotatorConfig (ZZZJ)Lcom/mikepenz/markdown/model/MarkdownAnnotatorConfig;
+	public static synthetic fun markdownAnnotatorConfig$default (ZZZJILjava/lang/Object;)Lcom/mikepenz/markdown/model/MarkdownAnnotatorConfig;
 }
 
 public final class com/mikepenz/markdown/model/MarkdownAnnotatorKt {

--- a/multiplatform-markdown-renderer/api/multiplatform-markdown-renderer.klib.api
+++ b/multiplatform-markdown-renderer/api/multiplatform-markdown-renderer.klib.api
@@ -111,8 +111,12 @@ abstract interface com.mikepenz.markdown.model/MarkdownAnnotator { // com.mikepe
 abstract interface com.mikepenz.markdown.model/MarkdownAnnotatorConfig { // com.mikepenz.markdown.model/MarkdownAnnotatorConfig|null[0]
     abstract val eolAsNewLine // com.mikepenz.markdown.model/MarkdownAnnotatorConfig.eolAsNewLine|{}eolAsNewLine[0]
         abstract fun <get-eolAsNewLine>(): kotlin/Boolean // com.mikepenz.markdown.model/MarkdownAnnotatorConfig.eolAsNewLine.<get-eolAsNewLine>|<get-eolAsNewLine>(){}[0]
+    open val imageAltTooltipHoverDelayMs // com.mikepenz.markdown.model/MarkdownAnnotatorConfig.imageAltTooltipHoverDelayMs|{}imageAltTooltipHoverDelayMs[0]
+        open fun <get-imageAltTooltipHoverDelayMs>(): kotlin/Long // com.mikepenz.markdown.model/MarkdownAnnotatorConfig.imageAltTooltipHoverDelayMs.<get-imageAltTooltipHoverDelayMs>|<get-imageAltTooltipHoverDelayMs>(){}[0]
     open val inlineImageAsBlock // com.mikepenz.markdown.model/MarkdownAnnotatorConfig.inlineImageAsBlock|{}inlineImageAsBlock[0]
         open fun <get-inlineImageAsBlock>(): kotlin/Boolean // com.mikepenz.markdown.model/MarkdownAnnotatorConfig.inlineImageAsBlock.<get-inlineImageAsBlock>|<get-inlineImageAsBlock>(){}[0]
+    open val showImageAltTooltip // com.mikepenz.markdown.model/MarkdownAnnotatorConfig.showImageAltTooltip|{}showImageAltTooltip[0]
+        open fun <get-showImageAltTooltip>(): kotlin/Boolean // com.mikepenz.markdown.model/MarkdownAnnotatorConfig.showImageAltTooltip.<get-showImageAltTooltip>|<get-showImageAltTooltip>(){}[0]
 
     final object Companion { // com.mikepenz.markdown.model/MarkdownAnnotatorConfig.Companion|null[0]
         final const val BLOCK_FALLBACK_LINE_MULTIPLIER // com.mikepenz.markdown.model/MarkdownAnnotatorConfig.Companion.BLOCK_FALLBACK_LINE_MULTIPLIER|{}BLOCK_FALLBACK_LINE_MULTIPLIER[0]
@@ -436,12 +440,16 @@ final class com.mikepenz.markdown.model/DefaultMarkdownAnnotator : com.mikepenz.
 }
 
 final class com.mikepenz.markdown.model/DefaultMarkdownAnnotatorConfig : com.mikepenz.markdown.model/MarkdownAnnotatorConfig { // com.mikepenz.markdown.model/DefaultMarkdownAnnotatorConfig|null[0]
-    constructor <init>(kotlin/Boolean = ..., kotlin/Boolean = ...) // com.mikepenz.markdown.model/DefaultMarkdownAnnotatorConfig.<init>|<init>(kotlin.Boolean;kotlin.Boolean){}[0]
+    constructor <init>(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Long = ...) // com.mikepenz.markdown.model/DefaultMarkdownAnnotatorConfig.<init>|<init>(kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Long){}[0]
 
     final val eolAsNewLine // com.mikepenz.markdown.model/DefaultMarkdownAnnotatorConfig.eolAsNewLine|{}eolAsNewLine[0]
         final fun <get-eolAsNewLine>(): kotlin/Boolean // com.mikepenz.markdown.model/DefaultMarkdownAnnotatorConfig.eolAsNewLine.<get-eolAsNewLine>|<get-eolAsNewLine>(){}[0]
+    final val imageAltTooltipHoverDelayMs // com.mikepenz.markdown.model/DefaultMarkdownAnnotatorConfig.imageAltTooltipHoverDelayMs|{}imageAltTooltipHoverDelayMs[0]
+        final fun <get-imageAltTooltipHoverDelayMs>(): kotlin/Long // com.mikepenz.markdown.model/DefaultMarkdownAnnotatorConfig.imageAltTooltipHoverDelayMs.<get-imageAltTooltipHoverDelayMs>|<get-imageAltTooltipHoverDelayMs>(){}[0]
     final val inlineImageAsBlock // com.mikepenz.markdown.model/DefaultMarkdownAnnotatorConfig.inlineImageAsBlock|{}inlineImageAsBlock[0]
         final fun <get-inlineImageAsBlock>(): kotlin/Boolean // com.mikepenz.markdown.model/DefaultMarkdownAnnotatorConfig.inlineImageAsBlock.<get-inlineImageAsBlock>|<get-inlineImageAsBlock>(){}[0]
+    final val showImageAltTooltip // com.mikepenz.markdown.model/DefaultMarkdownAnnotatorConfig.showImageAltTooltip|{}showImageAltTooltip[0]
+        final fun <get-showImageAltTooltip>(): kotlin/Boolean // com.mikepenz.markdown.model/DefaultMarkdownAnnotatorConfig.showImageAltTooltip.<get-showImageAltTooltip>|<get-showImageAltTooltip>(){}[0]
 
     final fun equals(kotlin/Any?): kotlin/Boolean // com.mikepenz.markdown.model/DefaultMarkdownAnnotatorConfig.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.mikepenz.markdown.model/DefaultMarkdownAnnotatorConfig.hashCode|hashCode(){}[0]
@@ -839,7 +847,7 @@ final fun com.mikepenz.markdown.model/com_mikepenz_markdown_model_State_Loading$
 final fun com.mikepenz.markdown.model/com_mikepenz_markdown_model_State_Success$stableprop_getter(): kotlin/Int // com.mikepenz.markdown.model/com_mikepenz_markdown_model_State_Success$stableprop_getter|com_mikepenz_markdown_model_State_Success$stableprop_getter(){}[0]
 final fun com.mikepenz.markdown.model/markdownAnimations(kotlin/Function1<androidx.compose.ui/Modifier, androidx.compose.ui/Modifier>?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.mikepenz.markdown.model/MarkdownAnimations // com.mikepenz.markdown.model/markdownAnimations|markdownAnimations(kotlin.Function1<androidx.compose.ui.Modifier,androidx.compose.ui.Modifier>?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
 final fun com.mikepenz.markdown.model/markdownAnnotator(com.mikepenz.markdown.model/MarkdownAnnotatorConfig = ..., kotlin/Function3<androidx.compose.ui.text/AnnotatedString.Builder, kotlin/String, org.intellij.markdown.ast/ASTNode, kotlin/Boolean>? = ...): com.mikepenz.markdown.model/MarkdownAnnotator // com.mikepenz.markdown.model/markdownAnnotator|markdownAnnotator(com.mikepenz.markdown.model.MarkdownAnnotatorConfig;kotlin.Function3<androidx.compose.ui.text.AnnotatedString.Builder,kotlin.String,org.intellij.markdown.ast.ASTNode,kotlin.Boolean>?){}[0]
-final fun com.mikepenz.markdown.model/markdownAnnotatorConfig(kotlin/Boolean = ..., kotlin/Boolean = ...): com.mikepenz.markdown.model/MarkdownAnnotatorConfig // com.mikepenz.markdown.model/markdownAnnotatorConfig|markdownAnnotatorConfig(kotlin.Boolean;kotlin.Boolean){}[0]
+final fun com.mikepenz.markdown.model/markdownAnnotatorConfig(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Long = ...): com.mikepenz.markdown.model/MarkdownAnnotatorConfig // com.mikepenz.markdown.model/markdownAnnotatorConfig|markdownAnnotatorConfig(kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Long){}[0]
 final fun com.mikepenz.markdown.model/markdownDimens(androidx.compose.ui.unit/Dp, androidx.compose.ui.unit/Dp, androidx.compose.ui.unit/Dp, androidx.compose.ui.unit/Dp, androidx.compose.ui.unit/Dp, androidx.compose.ui.unit/Dp, androidx.compose.ui.unit/Dp, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.mikepenz.markdown.model/MarkdownDimens // com.mikepenz.markdown.model/markdownDimens|markdownDimens(androidx.compose.ui.unit.Dp;androidx.compose.ui.unit.Dp;androidx.compose.ui.unit.Dp;androidx.compose.ui.unit.Dp;androidx.compose.ui.unit.Dp;androidx.compose.ui.unit.Dp;androidx.compose.ui.unit.Dp;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
 final fun com.mikepenz.markdown.model/markdownExtendedSpans(kotlin/Function2<androidx.compose.runtime/Composer, kotlin/Int, com.mikepenz.markdown.compose.extendedspans/ExtendedSpans>?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.mikepenz.markdown.model/MarkdownExtendedSpans // com.mikepenz.markdown.model/markdownExtendedSpans|markdownExtendedSpans(kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,com.mikepenz.markdown.compose.extendedspans.ExtendedSpans>?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
 final fun com.mikepenz.markdown.model/markdownInlineContent(kotlin.collections/Map<kotlin/String, androidx.compose.foundation.text/InlineTextContent>?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.mikepenz.markdown.model/MarkdownInlineContent // com.mikepenz.markdown.model/markdownInlineContent|markdownInlineContent(kotlin.collections.Map<kotlin.String,androidx.compose.foundation.text.InlineTextContent>?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownImage.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownImage.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
 import com.mikepenz.markdown.compose.LocalImageTransformer
 import com.mikepenz.markdown.compose.LocalReferenceLinkHandler
+import com.mikepenz.markdown.utils.resolveImageAlt
 import com.mikepenz.markdown.utils.resolveImageLink
 import org.intellij.markdown.ast.ASTNode
 
@@ -11,16 +12,19 @@ import org.intellij.markdown.ast.ASTNode
 fun MarkdownImage(content: String, node: ASTNode) {
 
     val link = node.resolveImageLink(content, LocalReferenceLinkHandler.current) ?: return
+    val alt = node.resolveImageAlt(content)
 
     LocalImageTransformer.current.transform(link)?.let { imageData ->
-        Image(
-            painter = imageData.painter,
-            contentDescription = imageData.contentDescription,
-            modifier = imageData.modifier,
-            alignment = imageData.alignment,
-            contentScale = imageData.contentScale,
-            alpha = imageData.alpha,
-            colorFilter = imageData.colorFilter
-        )
+        ImageAltTooltip(alt) {
+            Image(
+                painter = imageData.painter,
+                contentDescription = imageData.contentDescription ?: alt,
+                modifier = imageData.modifier,
+                alignment = imageData.alignment,
+                contentScale = imageData.contentScale,
+                alpha = imageData.alpha,
+                colorFilter = imageData.colorFilter
+            )
+        }
     }
 }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownImageAltTooltip.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownImageAltTooltip.kt
@@ -1,0 +1,103 @@
+package com.mikepenz.markdown.compose.elements
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import com.mikepenz.markdown.compose.LocalMarkdownAnnotator
+import kotlinx.coroutines.delay
+
+/**
+ * Wraps [content] with a small popup that surfaces [alt] on hover, gated by
+ * [com.mikepenz.markdown.model.MarkdownAnnotatorConfig.showImageAltTooltip].
+ * The hover dwell time is read from
+ * [com.mikepenz.markdown.model.MarkdownAnnotatorConfig.imageAltTooltipHoverDelayMs].
+ */
+@Composable
+internal fun ImageAltTooltip(alt: String?, content: @Composable () -> Unit) {
+    val config = LocalMarkdownAnnotator.current.config
+    if (!config.showImageAltTooltip || alt.isNullOrBlank()) {
+        content()
+        return
+    }
+
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+    val transitionState = remember { MutableTransitionState(false) }
+
+    LaunchedEffect(isHovered, config.imageAltTooltipHoverDelayMs) {
+        if (isHovered) {
+            delay(config.imageAltTooltipHoverDelayMs)
+            transitionState.targetState = true
+        } else {
+            transitionState.targetState = false
+        }
+    }
+
+    // Keep the popup mounted while either the target is visible or the
+    // exit animation is still running, so fadeOut can play before unmount.
+    val mounted = transitionState.currentState || transitionState.targetState
+
+    Box(modifier = Modifier.hoverable(interactionSource)) {
+        content()
+        if (mounted) {
+            Popup(popupPositionProvider = AnchorBelowPositionProvider) {
+                AnimatedVisibility(
+                    visibleState = transitionState,
+                    enter = fadeIn(),
+                    exit = fadeOut(),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .background(Color(0xCC000000), RoundedCornerShape(4.dp))
+                            .padding(horizontal = 8.dp, vertical = 4.dp),
+                    ) {
+                        BasicText(
+                            text = alt,
+                            style = TextStyle(color = Color.White, fontSize = 12.sp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private val AnchorBelowPositionProvider = object : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        val x = (anchorBounds.left + (anchorBounds.width - popupContentSize.width) / 2)
+            .coerceIn(0, (windowSize.width - popupContentSize.width).coerceAtLeast(0))
+        val y = (anchorBounds.bottom + 4).coerceAtMost(
+            (windowSize.height - popupContentSize.height).coerceAtLeast(0)
+        )
+        return IntOffset(x, y)
+    }
+}

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownAnnotatorConfig.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/model/MarkdownAnnotatorConfig.kt
@@ -18,6 +18,22 @@ interface MarkdownAnnotatorConfig {
     val inlineImageAsBlock: Boolean
         get() = true
 
+    /**
+     * If `true`, hovering an image surfaces its alt text in a small popup
+     * (web-style tooltip). On touch-only platforms a long-press also
+     * triggers it via [androidx.compose.foundation.hoverable]'s interaction
+     * source.
+     */
+    val showImageAltTooltip: Boolean
+        get() = false
+
+    /**
+     * Hover dwell time in milliseconds before the alt-text tooltip appears.
+     * Only honored when [showImageAltTooltip] is `true`.
+     */
+    val imageAltTooltipHoverDelayMs: Long
+        get() = 2_000L
+
     companion object {
         /**
          * Multiplier of the surrounding text's line height above which an
@@ -32,6 +48,8 @@ interface MarkdownAnnotatorConfig {
 class DefaultMarkdownAnnotatorConfig(
     override val eolAsNewLine: Boolean = false,
     override val inlineImageAsBlock: Boolean = true,
+    override val showImageAltTooltip: Boolean = false,
+    override val imageAltTooltipHoverDelayMs: Long = 2_000L,
 ) : MarkdownAnnotatorConfig {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -41,12 +59,16 @@ class DefaultMarkdownAnnotatorConfig(
 
         if (eolAsNewLine != other.eolAsNewLine) return false
         if (inlineImageAsBlock != other.inlineImageAsBlock) return false
+        if (showImageAltTooltip != other.showImageAltTooltip) return false
+        if (imageAltTooltipHoverDelayMs != other.imageAltTooltipHoverDelayMs) return false
         return true
     }
 
     override fun hashCode(): Int {
         var result = eolAsNewLine.hashCode()
         result = 31 * result + inlineImageAsBlock.hashCode()
+        result = 31 * result + showImageAltTooltip.hashCode()
+        result = 31 * result + imageAltTooltipHoverDelayMs.hashCode()
         return result
     }
 }
@@ -54,7 +76,11 @@ class DefaultMarkdownAnnotatorConfig(
 fun markdownAnnotatorConfig(
     eolAsNewLine: Boolean = false,
     inlineImageAsBlock: Boolean = true,
+    showImageAltTooltip: Boolean = false,
+    imageAltTooltipHoverDelayMs: Long = 2_000L,
 ): MarkdownAnnotatorConfig = DefaultMarkdownAnnotatorConfig(
     eolAsNewLine = eolAsNewLine,
     inlineImageAsBlock = inlineImageAsBlock,
+    showImageAltTooltip = showImageAltTooltip,
+    imageAltTooltipHoverDelayMs = imageAltTooltipHoverDelayMs,
 )

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
@@ -21,6 +21,23 @@ import org.intellij.markdown.flavours.gfm.GFMTokenTypes
 const val MARKDOWN_TAG_IMAGE_URL = "MARKDOWN_IMAGE_URL"
 
 /**
+ * Resolve the alt text for an `IMAGE` node — used as the contents of the
+ * web-style hover tooltip. Falls back through `LINK_TEXT` (inline + full
+ * reference forms) and `LINK_LABEL` (short reference form).
+ */
+internal fun ASTNode.resolveImageAlt(content: String): String? {
+    findChildOfTypeRecursive(MarkdownElementTypes.LINK_TEXT)?.let {
+        val text = it.getUnescapedTextInNode(content).trim('[', ']').trim()
+        if (text.isNotEmpty()) return text
+    }
+    findChildOfTypeRecursive(MarkdownElementTypes.LINK_LABEL)?.let {
+        val text = it.getUnescapedTextInNode(content).trim('[', ']').trim()
+        if (text.isNotEmpty()) return text
+    }
+    return null
+}
+
+/**
  * Resolve the destination URL for an `IMAGE` node. Falls back to looking up
  * a `FULL_REFERENCE_LINK` / `SHORT_REFERENCE_LINK` descendant's `LINK_LABEL`
  * via the supplied [referenceLinkHandler] when no inline `LINK_DESTINATION`

--- a/sample/shared/src/commonMain/kotlin/com/mikepenz/markdown/sample/MarkDownPage.kt
+++ b/sample/shared/src/commonMain/kotlin/com/mikepenz/markdown/sample/MarkDownPage.kt
@@ -23,6 +23,8 @@ import com.mikepenz.markdown.compose.extendedspans.SquigglyUnderlineSpanPainter
 import com.mikepenz.markdown.compose.extendedspans.rememberSquigglyUnderlineAnimator
 import com.mikepenz.markdown.m3.Markdown
 import com.mikepenz.markdown.m3.elements.MarkdownCheckBox
+import com.mikepenz.markdown.model.markdownAnnotator
+import com.mikepenz.markdown.model.markdownAnnotatorConfig
 import com.mikepenz.markdown.model.markdownExtendedSpans
 import com.mikepenz.markdown.model.rememberMarkdownState
 import com.mikepenz.markdown.sample.shared.resources.Res
@@ -62,6 +64,7 @@ internal fun MarkDownPage(modifier: Modifier = Modifier) {
                 },
                 checkbox = { MarkdownCheckBox(it.content, it.node, it.typography.text) },
             ),
+            annotator = markdownAnnotator(markdownAnnotatorConfig(showImageAltTooltip = true)),
             imageTransformer = Coil3ImageTransformerImpl,
             extendedSpans = markdownExtendedSpans {
                 val animator = rememberSquigglyUnderlineAnimator()


### PR DESCRIPTION
## Summary
- Opt-in web-style tooltip surfaces image alt text on hover (and long-press on touch).
- New `MarkdownAnnotatorConfig.showImageAltTooltip` + `imageAltTooltipHoverDelayMs` (default off / 2000ms).
- `MarkdownImage` falls back to alt text when `ImageData.contentDescription` is null.
- Sample enables the tooltip.

## Test plan
- [ ] `./gradlew apiCheck`
- [ ] `./gradlew lintDebug`
- [ ] Run desktop sample, hover an image, verify tooltip
- [ ] Run android sample, long-press image, verify tooltip
- [ ] Run web sample, hover image, verify tooltip
- [ ] Verify tooltip stays off when `showImageAltTooltip = false` (default)