### PR TITLE
feat(sample): add images tab showcasing issue #494

### DIFF
--- a/sample/shared/src/commonMain/composeResources/files/sample-images.md
+++ b/sample/shared/src/commonMain/composeResources/files/sample-images.md
@@ -1,0 +1,12 @@
+## Images
+
+![Minion](https://octodex.github.com/images/minion.png)
+![Stormtroopocat](https://octodex.github.com/images/stormtroopocat.jpg "The Stormtroopocat")
+
+Like links, Images also have a footnote style syntax
+
+![Alt text][id]
+
+With a reference later in the document defining the URL location:
+
+[id]: https://octodex.github.com/images/dojocat.jpg  "The Dojocat"

--- a/sample/shared/src/commonMain/kotlin/com/mikepenz/markdown/sample/SamplesPage.kt
+++ b/sample/shared/src/commonMain/kotlin/com/mikepenz/markdown/sample/SamplesPage.kt
@@ -22,6 +22,7 @@ internal data class MarkdownSample(
 private val SAMPLES = listOf(
     MarkdownSample("Playground", "files/sample.md"),
     MarkdownSample("Tables", "files/sample-tables.md"),
+    MarkdownSample("Images", "files/sample-images.md"),
 )
 
 @Composable


### PR DESCRIPTION
## Summary
- New \"Images\" tab in the samples app with the reference-style image markdown from issue #494.
- Adds `sample-images.md` containing both inline and reference (`![alt][id]` + `[id]: url`) image syntax.

Refs #494

## Test plan
- [ ] Run sample app, switch to Images tab, verify both inline and reference images render
- [ ] Update Paparazzi snapshots if needed