### PR TITLE
chore(deps): update version-catalog to 0.17.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ coil2 = "2.7.0"
 markdown = "0.7.5"
 ktor = "3.5.0"
 highlights = "1.1.0"
-kotlinx-coroutines = "1.11.0"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
@@ -20,7 +19,6 @@ ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "kto
 ktor-client-java = { module = "io.ktor:ktor-client-java", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 highlights = { module = "dev.snipme:highlights", version.ref = "highlights" }
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
 [bundles]
 coil = [

--- a/multiplatform-markdown-renderer-code/api/jvm/multiplatform-markdown-renderer-code.api
+++ b/multiplatform-markdown-renderer-code/api/jvm/multiplatform-markdown-renderer-code.api
@@ -1,8 +1,8 @@
 public final class com/mikepenz/markdown/compose/elements/ComposableSingletons$MarkdownHighlightedCodeKt {
 	public static final field INSTANCE Lcom/mikepenz/markdown/compose/elements/ComposableSingletons$MarkdownHighlightedCodeKt;
 	public fun <init> ()V
-	public final fun getLambda$-621386773$multiplatform_markdown_renderer_code ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$986930703$multiplatform_markdown_renderer_code ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-621386773$com_mikepenz_multiplatform_markdown_renderer_code ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$986930703$com_mikepenz_multiplatform_markdown_renderer_code ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/mikepenz/markdown/compose/elements/MarkdownHighlightedCodeKt {

--- a/multiplatform-markdown-renderer-m2/api/jvm/multiplatform-markdown-renderer-m2.api
+++ b/multiplatform-markdown-renderer-m2/api/jvm/multiplatform-markdown-renderer-m2.api
@@ -1,13 +1,13 @@
 public final class com/mikepenz/markdown/m2/ComposableSingletons$MarkdownKt {
 	public static final field INSTANCE Lcom/mikepenz/markdown/m2/ComposableSingletons$MarkdownKt;
 	public fun <init> ()V
-	public final fun getLambda$-1669617445$multiplatform_markdown_renderer_m2 ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1112484843$multiplatform_markdown_renderer_m2 ()Lkotlin/jvm/functions/Function5;
-	public final fun getLambda$1405124674$multiplatform_markdown_renderer_m2 ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1890655630$multiplatform_markdown_renderer_m2 ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1996475994$multiplatform_markdown_renderer_m2 ()Lkotlin/jvm/functions/Function5;
-	public final fun getLambda$598402550$multiplatform_markdown_renderer_m2 ()Lkotlin/jvm/functions/Function5;
-	public final fun getLambda$925370143$multiplatform_markdown_renderer_m2 ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1669617445$com_mikepenz_multiplatform_markdown_renderer_m2 ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1112484843$com_mikepenz_multiplatform_markdown_renderer_m2 ()Lkotlin/jvm/functions/Function5;
+	public final fun getLambda$1405124674$com_mikepenz_multiplatform_markdown_renderer_m2 ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1890655630$com_mikepenz_multiplatform_markdown_renderer_m2 ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1996475994$com_mikepenz_multiplatform_markdown_renderer_m2 ()Lkotlin/jvm/functions/Function5;
+	public final fun getLambda$598402550$com_mikepenz_multiplatform_markdown_renderer_m2 ()Lkotlin/jvm/functions/Function5;
+	public final fun getLambda$925370143$com_mikepenz_multiplatform_markdown_renderer_m2 ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/mikepenz/markdown/m2/MarkdownColorsKt {
@@ -28,7 +28,7 @@ public final class com/mikepenz/markdown/m2/MarkdownTypographyKt {
 public final class com/mikepenz/markdown/m2/elements/ComposableSingletons$MarkdownCheckBoxKt {
 	public static final field INSTANCE Lcom/mikepenz/markdown/m2/elements/ComposableSingletons$MarkdownCheckBoxKt;
 	public fun <init> ()V
-	public final fun getLambda$-1027770773$multiplatform_markdown_renderer_m2 ()Lkotlin/jvm/functions/Function4;
+	public final fun getLambda$-1027770773$com_mikepenz_multiplatform_markdown_renderer_m2 ()Lkotlin/jvm/functions/Function4;
 }
 
 public final class com/mikepenz/markdown/m2/elements/MarkdownCheckBoxKt {

--- a/multiplatform-markdown-renderer-m3/api/jvm/multiplatform-markdown-renderer-m3.api
+++ b/multiplatform-markdown-renderer-m3/api/jvm/multiplatform-markdown-renderer-m3.api
@@ -1,13 +1,13 @@
 public final class com/mikepenz/markdown/m3/ComposableSingletons$MarkdownKt {
 	public static final field INSTANCE Lcom/mikepenz/markdown/m3/ComposableSingletons$MarkdownKt;
 	public fun <init> ()V
-	public final fun getLambda$-398669803$multiplatform_markdown_renderer_m3 ()Lkotlin/jvm/functions/Function5;
-	public final fun getLambda$-71702210$multiplatform_markdown_renderer_m3 ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$115412490$multiplatform_markdown_renderer_m3 ()Lkotlin/jvm/functions/Function5;
-	public final fun getLambda$1628277498$multiplatform_markdown_renderer_m3 ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$408052321$multiplatform_markdown_renderer_m3 ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$893583277$multiplatform_markdown_renderer_m3 ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$999403641$multiplatform_markdown_renderer_m3 ()Lkotlin/jvm/functions/Function5;
+	public final fun getLambda$-398669803$com_mikepenz_multiplatform_markdown_renderer_m3 ()Lkotlin/jvm/functions/Function5;
+	public final fun getLambda$-71702210$com_mikepenz_multiplatform_markdown_renderer_m3 ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$115412490$com_mikepenz_multiplatform_markdown_renderer_m3 ()Lkotlin/jvm/functions/Function5;
+	public final fun getLambda$1628277498$com_mikepenz_multiplatform_markdown_renderer_m3 ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$408052321$com_mikepenz_multiplatform_markdown_renderer_m3 ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$893583277$com_mikepenz_multiplatform_markdown_renderer_m3 ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$999403641$com_mikepenz_multiplatform_markdown_renderer_m3 ()Lkotlin/jvm/functions/Function5;
 }
 
 public final class com/mikepenz/markdown/m3/MarkdownColorsKt {
@@ -28,7 +28,7 @@ public final class com/mikepenz/markdown/m3/MarkdownTypographyKt {
 public final class com/mikepenz/markdown/m3/elements/ComposableSingletons$MarkdownCheckBoxKt {
 	public static final field INSTANCE Lcom/mikepenz/markdown/m3/elements/ComposableSingletons$MarkdownCheckBoxKt;
 	public fun <init> ()V
-	public final fun getLambda$697710124$multiplatform_markdown_renderer_m3 ()Lkotlin/jvm/functions/Function4;
+	public final fun getLambda$697710124$com_mikepenz_multiplatform_markdown_renderer_m3 ()Lkotlin/jvm/functions/Function4;
 }
 
 public final class com/mikepenz/markdown/m3/elements/MarkdownCheckBoxKt {

--- a/multiplatform-markdown-renderer/api/jvm/multiplatform-markdown-renderer.api
+++ b/multiplatform-markdown-renderer/api/jvm/multiplatform-markdown-renderer.api
@@ -37,9 +37,9 @@ public final class com/mikepenz/markdown/annotator/DefaultAnnotatorSettings : co
 public final class com/mikepenz/markdown/compose/ComposableSingletons$MarkdownKt {
 	public static final field INSTANCE Lcom/mikepenz/markdown/compose/ComposableSingletons$MarkdownKt;
 	public fun <init> ()V
-	public final fun getLambda$-2063790006$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function5;
-	public final fun getLambda$-322200773$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function5;
-	public final fun getLambda$-830612685$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function5;
+	public final fun getLambda$-2063790006$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function5;
+	public final fun getLambda$-322200773$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function5;
+	public final fun getLambda$-830612685$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function5;
 }
 
 public final class com/mikepenz/markdown/compose/ComposeLocalKt {
@@ -81,27 +81,27 @@ public final class com/mikepenz/markdown/compose/MarkdownKt {
 public final class com/mikepenz/markdown/compose/components/ComposableSingletons$MarkdownComponentsKt {
 	public static final field INSTANCE Lcom/mikepenz/markdown/compose/components/ComposableSingletons$MarkdownComponentsKt;
 	public fun <init> ()V
-	public final fun getLambda$-1079294572$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-1347673484$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-1643949077$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-1690655072$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-1755130397$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-1794801381$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-1981090537$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-624343772$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-700682889$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-852522976$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-899602067$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1027552049$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1409050274$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1604122825$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1659920708$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1702810816$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1752436318$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$242326187$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$278263649$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$506442853$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$572024191$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1079294572$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1347673484$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1643949077$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1690655072$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1755130397$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1794801381$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1981090537$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-624343772$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-700682889$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-852522976$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-899602067$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1027552049$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1409050274$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1604122825$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1659920708$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1702810816$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1752436318$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$242326187$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$278263649$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$506442853$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$572024191$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/mikepenz/markdown/compose/components/CurrentComponentsBridge {
@@ -183,8 +183,8 @@ public final class com/mikepenz/markdown/compose/components/MarkdownComponentsKt
 public final class com/mikepenz/markdown/compose/elements/ComposableSingletons$MarkdownCodeKt {
 	public static final field INSTANCE Lcom/mikepenz/markdown/compose/elements/ComposableSingletons$MarkdownCodeKt;
 	public fun <init> ()V
-	public final fun getLambda$-449689539$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function5;
-	public final fun getLambda$591785369$multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function5;
+	public final fun getLambda$-449689539$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function5;
+	public final fun getLambda$591785369$com_mikepenz_multiplatform_markdown_renderer ()Lkotlin/jvm/functions/Function5;
 }
 
 public final class com/mikepenz/markdown/compose/elements/MarkdownBlockQuoteKt {

--- a/multiplatform-markdown-renderer/build.gradle.kts
+++ b/multiplatform-markdown-renderer/build.gradle.kts
@@ -21,7 +21,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
-            implementation(libs.kotlinx.coroutines.test)
+            implementation(baseLibs.kotlinx.coroutines.test)
         }
     }
 }

--- a/sample/shared/src/commonMain/kotlin/com/mikepenz/markdown/sample/SamplesPage.kt
+++ b/sample/shared/src/commonMain/kotlin/com/mikepenz/markdown/sample/SamplesPage.kt
@@ -29,7 +29,7 @@ private val SAMPLES = listOf(
 
 @Composable
 internal fun SamplesPage(modifier: Modifier = Modifier) {
-    var selected by rememberSaveable { mutableIntStateOf(1) }
+    var selected by rememberSaveable { mutableIntStateOf(0) }
     val samples = remember { SAMPLES }
 
     Column(modifier = modifier.fillMaxSize()) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,7 +28,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.16.0")
+            from("com.mikepenz:version-catalog:0.17.1")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Upgrade `com.mikepenz:version-catalog` 0.16.0 -> 0.17.1
- Remove duplicated `kotlinx-coroutines-test` spec (now provided by shared catalog); core/test now both consume `baseLibs`
- Regenerate API dump (Kotlin 2.4.0 prefixes synthetic Compose lambda singletons with the group id — internal-only, no public API change)
- Reset sample default tab to index 0

### Transitive changes via version-catalog 0.16.0 -> 0.17.1
- compileSdk 36 -> 37
- targetSdk 36 -> 37
- compose 1.11.1 -> 1.11.2
- compose-wear 1.6.1 -> 1.6.2
- compose-multiplatform 1.11.0 -> 1.11.1
- kotlin 2.3.21 -> 2.4.0
- screenshot 0.0.1-alpha14 -> 0.0.1-alpha15
- lintGradle 1.0.0-beta01 -> 1.0.0-rc01
- aboutLibraries 14.2.0 -> 15.0.0-b03
- composeHotReload 1.1.1 -> 1.2.0-alpha01
- stabilityAnalyzer 0.7.5 -> 0.9.0
- adds kotlinx-coroutines-test

## Test plan
- `./gradlew apiDump` ✅
- `./gradlew :sample:android:recordPaparazzi` ✅ (no snapshot changes)