### PR TITLE
fix: do not directly specify inlineCode font size

### DIFF
--- a/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/MarkdownTypography.kt
+++ b/multiplatform-markdown-renderer-m2/src/commonMain/kotlin/com/mikepenz/markdown/m2/MarkdownTypography.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.TextUnit
 import com.mikepenz.markdown.model.DefaultMarkdownTypography
 import com.mikepenz.markdown.model.MarkdownTypography
 
@@ -22,7 +23,9 @@ fun markdownTypography(
     h6: TextStyle = MaterialTheme.typography.h6,
     text: TextStyle = MaterialTheme.typography.body1,
     code: TextStyle = MaterialTheme.typography.body2.copy(fontFamily = FontFamily.Monospace),
-    inlineCode: TextStyle = text.copy(fontFamily = FontFamily.Monospace),
+    inlineCode: TextStyle = text.copy(
+        fontFamily = FontFamily.Monospace, fontSize = TextUnit.Unspecified
+    ),
     quote: TextStyle = MaterialTheme.typography.body2.plus(SpanStyle(fontStyle = FontStyle.Italic)),
     paragraph: TextStyle = MaterialTheme.typography.body1,
     ordered: TextStyle = MaterialTheme.typography.body1,

--- a/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/MarkdownTypography.kt
+++ b/multiplatform-markdown-renderer-m3/src/commonMain/kotlin/com/mikepenz/markdown/m3/MarkdownTypography.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.TextUnit
 import com.mikepenz.markdown.model.DefaultMarkdownTypography
 import com.mikepenz.markdown.model.MarkdownTypography
 
@@ -22,7 +23,9 @@ fun markdownTypography(
     h6: TextStyle = MaterialTheme.typography.titleLarge,
     text: TextStyle = MaterialTheme.typography.bodyLarge,
     code: TextStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
-    inlineCode: TextStyle = text.copy(fontFamily = FontFamily.Monospace),
+    inlineCode: TextStyle = text.copy(
+        fontFamily = FontFamily.Monospace, fontSize = TextUnit.Unspecified
+    ),
     quote: TextStyle = MaterialTheme.typography.bodyMedium.plus(SpanStyle(fontStyle = FontStyle.Italic)),
     paragraph: TextStyle = MaterialTheme.typography.bodyLarge,
     ordered: TextStyle = MaterialTheme.typography.bodyLarge,


### PR DESCRIPTION
## Description
This pull request updates the markdown typography configuration for both Material 2 and Material 3 Compose implementations to improve the handling of inline code styling. The main change is to explicitly set the font size of inline code elements to `TextUnit.Unspecified`, ensuring they inherit the surrounding text size rather than overriding it. This helps maintain consistent appearance in markdown rendering.

### Before
<img width="200"  alt="31e27e734248a1ed6803f8975d75b520" src="https://github.com/user-attachments/assets/b12b0d4c-a8d9-4821-8c62-7df010ebd2fc" />

### After
<img width="200" alt="45f35c7f6cccdbe0f6fb4dc8c0c70e92" src="https://github.com/user-attachments/assets/3b19fa92-2cda-4550-8b47-25905b7d62b4" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `./gradlew :multiplatform-markdown-renderer:assemble`
- [x] `./gradlew apiCheck`

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
