### PR TITLE
fix: resolve TextUnit to px without crashing on em/unspecified units

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/elements/MarkdownText.kt
@@ -49,6 +49,7 @@ import com.mikepenz.markdown.model.ImageTransformer
 import com.mikepenz.markdown.model.ImageWidth
 import com.mikepenz.markdown.model.MarkdownAnnotatorConfig
 import com.mikepenz.markdown.utils.MARKDOWN_TAG_IMAGE_URL
+import com.mikepenz.markdown.utils.toPxOrZero
 import org.intellij.markdown.IElementType
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.ast.ASTNode
@@ -130,10 +131,15 @@ fun MarkdownText(
     val imageSizeByLink = remember { mutableStateMapOf<String, Size>() }
 
     // Resolved line height in pixels; used to decide whether an image
-    // should be inline or promoted to a block element.
+    // should be inline or promoted to a block element. Resolves `sp`, `em`,
+    // and unspecified units without crashing (`toPx()` only supports `sp`).
     val lineHeightPx = with(density) {
-        val lh = if (style.lineHeight.isSpecified) style.lineHeight else style.fontSize
-        if (lh.isSpecified) lh.toPx() else 0f
+        // `em` is relative to the font size, so resolve that to px first.
+        val fontSizePx = toPxOrZero(style.fontSize, relativeToPx = 0f)
+        when {
+            style.lineHeight.isSpecified -> toPxOrZero(style.lineHeight, relativeToPx = fontSizePx)
+            else -> fontSizePx
+        }
     }
 
     val inlineImageAsBlock = annotatorConfig.inlineImageAsBlock

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/RoundedCornerSpanPainter.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/RoundedCornerSpanPainter.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.util.fastForEachIndexed
 import com.mikepenz.markdown.compose.extendedspans.internal.deserializeToColor
 import com.mikepenz.markdown.compose.extendedspans.internal.serialize
 import com.mikepenz.markdown.compose.extendedspans.internal.update
+import com.mikepenz.markdown.utils.toPxOrZero
 
 /**
  * Draws round rectangles behind text annotated using `SpanStyle(background = …)`.
@@ -81,7 +82,7 @@ class RoundedCornerSpanPainter(
         val annotations = text.getStringAnnotations(TAG, start = 0, end = text.length)
 
         return SpanDrawInstructions {
-            val cornerRadius = CornerRadius(cornerRadius.toPx())
+            val cornerRadius = CornerRadius(toPxOrZero(cornerRadius))
 
             annotations.fastForEach { annotation ->
                 val backgroundColor = annotation.item.deserializeToColor()!!
@@ -95,10 +96,10 @@ class RoundedCornerSpanPainter(
                     path.addRoundRect(
                         RoundRect(
                             rect = box.copy(
-                                left = box.left - padding.horizontal.toPx(),
-                                right = box.right + padding.horizontal.toPx(),
-                                top = box.top - padding.vertical.toPx() + topMargin.toPx(),
-                                bottom = box.bottom + padding.vertical.toPx() - bottomMargin.toPx(),
+                                left = box.left - toPxOrZero(padding.horizontal),
+                                right = box.right + toPxOrZero(padding.horizontal),
+                                top = box.top - toPxOrZero(padding.vertical) + toPxOrZero(topMargin),
+                                bottom = box.bottom + toPxOrZero(padding.vertical) - toPxOrZero(bottomMargin),
                             ),
                             topLeft = if (index == 0) cornerRadius else CornerRadius.Zero,
                             bottomLeft = if (index == 0) cornerRadius else CornerRadius.Zero,
@@ -116,7 +117,7 @@ class RoundedCornerSpanPainter(
                             path = path,
                             color = stroke.color(backgroundColor),
                             style = Stroke(
-                                width = stroke.width.toPx(),
+                                width = toPxOrZero(stroke.width),
                             )
                         )
                     }

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/SquigglyUnderlineSpanPainter.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/compose/extendedspans/SquigglyUnderlineSpanPainter.kt
@@ -39,6 +39,7 @@ import com.mikepenz.markdown.compose.extendedspans.internal.deserializeToColor
 import com.mikepenz.markdown.compose.extendedspans.internal.fastMapRange
 import com.mikepenz.markdown.compose.extendedspans.internal.serialize
 import com.mikepenz.markdown.compose.extendedspans.internal.update
+import com.mikepenz.markdown.utils.toPxOrZero
 import kotlin.math.PI
 import kotlin.math.ceil
 import kotlin.math.sin
@@ -136,10 +137,10 @@ class SquigglyUnderlineSpanPainter(
 
         return SpanDrawInstructions {
             val pathStyle = Stroke(
-                width = width.toPx(),
+                width = toPxOrZero(width),
                 join = StrokeJoin.Round,
                 cap = StrokeCap.Round,
-                pathEffect = PathEffect.cornerPathEffect(radius = wavelength.toPx()), // For slightly smoother waves.
+                pathEffect = PathEffect.cornerPathEffect(radius = toPxOrZero(wavelength)), // For slightly smoother waves.
             )
 
             annotations.fastForEach { annotation ->
@@ -166,19 +167,24 @@ class SquigglyUnderlineSpanPainter(
     /**
      * Maths copied from [squigglyspans](https://github.com/samruston/squigglyspans).
      */
-    private fun Path.buildSquigglesFor(box: Rect, density: Density) = density.run {
-        val lineStart = box.left + (width.toPx() / 2)
-        val lineEnd = box.right - (width.toPx() / 2)
-        val lineBottom = box.bottom + bottomOffset.toPx()
+    private fun Path.buildSquigglesFor(box: Rect, density: Density): Unit = density.run {
+        val wavelengthPx = toPxOrZero(wavelength)
+        // Nothing sensible to draw without a wavelength; guard against the
+        // division below blowing up to an unbounded point count (e.g. `em` units).
+        if (wavelengthPx <= 0f) return
 
-        val segmentWidth = wavelength.toPx() / SEGMENTS_PER_WAVELENGTH
+        val lineStart = box.left + (toPxOrZero(width) / 2)
+        val lineEnd = box.right - (toPxOrZero(width) / 2)
+        val lineBottom = box.bottom + toPxOrZero(bottomOffset)
+
+        val segmentWidth = wavelengthPx / SEGMENTS_PER_WAVELENGTH
         val numOfPoints = ceil((lineEnd - lineStart) / segmentWidth).toInt() + 1
 
         var pointX = lineStart
         fastMapRange(0, numOfPoints) { point ->
-            val proportionOfWavelength = (pointX - lineStart) / wavelength.toPx()
+            val proportionOfWavelength = (pointX - lineStart) / wavelengthPx
             val radiansX = proportionOfWavelength * TWO_PI + (TWO_PI * animator.animationProgress.value)
-            val offsetY = lineBottom + (sin(radiansX) * amplitude.toPx())
+            val offsetY = lineBottom + (sin(radiansX) * toPxOrZero(amplitude))
 
             when (point) {
                 0 -> moveTo(pointX, offsetY)

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
@@ -2,6 +2,9 @@ package com.mikepenz.markdown.utils
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.TextUnitType
 import com.mikepenz.markdown.compose.LocalMarkdownColors
 import com.mikepenz.markdown.model.MarkdownTypography
 import com.mikepenz.markdown.model.ReferenceLinkHandler
@@ -165,6 +168,21 @@ internal fun lookupLinkDefinition(
     }
 }
 
+
+/**
+ * Resolves a [TextUnit] to pixels without crashing on non-`sp` units.
+ *
+ * [TextUnit.toPx] only supports `sp`; calling it on an `em` (or unspecified)
+ * value throws. This resolves:
+ * - `sp` -> via density
+ * - `em` -> [relativeToPx] (the value it is relative to, e.g. the font size) scaled by the em factor
+ * - unspecified / unknown -> `0f`
+ */
+internal fun Density.toPxOrZero(unit: TextUnit, relativeToPx: Float = 0f): Float = when (unit.type) {
+    TextUnitType.Sp -> unit.toPx()
+    TextUnitType.Em -> unit.value * relativeToPx
+    else -> 0f
+}
 
 /**
  * Extension property to get the `SpanStyle` for inline code text.


### PR DESCRIPTION
## Summary

`TextUnit.toPx()` only supports `sp` — calling it on an `em` or unspecified value throws. Several places passed user-controllable `TextUnit` values straight into `toPx()`, making the renderer fragile against perfectly valid `TextStyle` inputs.

Originally reported for `MarkdownText` line-height resolution (`MarkdownText.kt:134`); a codebase sweep found the same crash class in the extended span painters.

## Changes

- **`utils/Extensions.kt`** — new shared `Density.toPxOrZero(unit, relativeToPx = 0f)` helper:
  - `sp` → resolved via density
  - `em` → `relativeToPx` (what it's relative to, e.g. font size) × em factor
  - unspecified / unknown → `0f`
- **`MarkdownText.kt`** — line height now resolved through the helper; `em` line height is resolved relative to the font size in px.
- **`SquigglyUnderlineSpanPainter.kt`** — `width` / `wavelength` / `amplitude` / `bottomOffset` routed through the helper. Added a `wavelengthPx <= 0f` guard to prevent a divide-by-zero producing an unbounded point count (a hang would be worse than the original crash).
- **`RoundedCornerSpanPainter.kt`** — `cornerRadius` / `padding` / `topMargin` / `bottomMargin` / `Stroke.width` routed through the helper.

`MarkdownBlockQuote.kt` was checked — it uses `Dp.toPx()`, which never throws, so it was left unchanged.

## Notes

- Span painters use the `em = 0` fallback: there is no font-size anchor in the draw scope, so `em` decorations degrade gracefully instead of crashing.
- All changes are `internal` / behavioral — no public API change, `apiCheck` unaffected.

## Test plan

- [x] `./gradlew :multiplatform-markdown-renderer:compileKotlinJvm`
- [ ] `./gradlew :sample:android:verifyPaparazzi` to confirm no visual regression in the default `sp` path