### PR TITLE
chore(deps): update com.mikepenz:version-catalog 0.17.1 -> 0.17.3

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,7 +28,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.17.1")
+            from("com.mikepenz:version-catalog:0.17.3")
         }
     }
 }


### PR DESCRIPTION
Bumps the shared convention plugin pin `com.mikepenz:version-catalog` from `0.17.1` to `0.17.3` in `settings.gradle.kts`.

### via com.mikepenz:version-catalog 0.17.1 -> 0.17.3
- compose 1.11.2 -> 1.11.3
- kotlinxCollectionsImmutable 0.4.0 -> 0.5.0
- lintGradle 1.0.0-rc01 -> 1.0.0
- aboutLibraries 15.0.0-b03 -> 15.0.0-rc01
- composeHotReload 1.2.0-alpha01 -> 1.2.0-alpha02
- stabilityAnalyzer 0.9.0 -> 0.10.0

### Verification
- `./gradlew help` — BUILD SUCCESSFUL (forces settings eval, catalog import, convention plugin resolution; all modules configured)
- `./gradlew tasks` — BUILD SUCCESSFUL (configuration-level verification across all modules)
