### PR TITLE
fix: render email autolinks (#608)

### DIFF
--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/annotator/AnnotatedStringKtx.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/annotator/AnnotatedStringKtx.kt
@@ -314,10 +314,11 @@ fun AnnotatedString.Builder.buildMarkdownAnnotatedString(
 
                     // Token Types
                     MarkdownTokenTypes.TEXT -> append(child.getUnescapedTextInNode(content))
-                    MarkdownTokenTypes.EMAIL_AUTOLINK -> if (child.parent == MarkdownElementTypes.LINK_TEXT) {
+                    MarkdownTokenTypes.EMAIL_AUTOLINK -> if (parentType == MarkdownElementTypes.LINK_TEXT) {
                         append(child.getUnescapedTextInNode(content))
                     } else appendEmailAutoLink(content, child, annotatorSettings)
-                    GFMTokenTypes.GFM_AUTOLINK -> if (child.parent == MarkdownElementTypes.LINK_TEXT) {
+
+                    GFMTokenTypes.GFM_AUTOLINK -> if (parentType == MarkdownElementTypes.LINK_TEXT) {
                         append(child.getUnescapedTextInNode(content))
                     } else appendAutoLink(content, child, annotatorSettings)
 

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/annotator/AnnotatedStringKtx.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/annotator/AnnotatedStringKtx.kt
@@ -16,11 +16,10 @@ import com.mikepenz.markdown.model.MarkdownAnnotator
 import com.mikepenz.markdown.model.ReferenceLinkHandler
 import com.mikepenz.markdown.model.markdownAnnotator
 import com.mikepenz.markdown.utils.MARKDOWN_TAG_IMAGE_URL
-import com.mikepenz.markdown.utils.findChildOfTypeRecursive
 import com.mikepenz.markdown.utils.getUnescapedTextInNode
-import com.mikepenz.markdown.utils.resolveImageLink
 import com.mikepenz.markdown.utils.innerList
 import com.mikepenz.markdown.utils.mapAutoLinkToType
+import com.mikepenz.markdown.utils.resolveImageLink
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
@@ -217,6 +216,23 @@ fun AnnotatedString.Builder.appendAutoLink(
 }
 
 /**
+ * Appends an email auto-link without its surrounding angle brackets.
+ */
+private fun AnnotatedString.Builder.appendEmailAutoLink(
+    content: String,
+    node: ASTNode,
+    annotatorSettings: AnnotatorSettings,
+) {
+    val email = node.getUnescapedTextInNode(content)
+    val destination = "mailto:$email"
+
+    annotatorSettings.referenceLinkHandler?.store(email, destination)
+    withLink(LinkAnnotation.Url(destination, annotatorSettings.linkTextSpanStyle, linkInteractionListener = annotatorSettings.linkInteractionListener)) {
+        append(email)
+    }
+}
+
+/**
  * Builds an [AnnotatedString] with the contents of the given Markdown [ASTNode] node.
  *
  * This method automatically constructs the string with child components like:
@@ -252,7 +268,7 @@ fun AnnotatedString.Builder.buildMarkdownAnnotatedString(
     val annotate = annotatorSettings.annotator.annotate
     val eolAsNewLine = annotatorSettings.annotator.config.eolAsNewLine
     var skipIfNext: Any? = null
-    children.forEach { child ->
+    children.forEachIndexed { index, child ->
         if (skipIfNext == null || skipIfNext != child.type) {
             if (annotate == null || !annotate(content, child)) {
                 val parentType = child.parent?.type
@@ -298,6 +314,9 @@ fun AnnotatedString.Builder.buildMarkdownAnnotatedString(
 
                     // Token Types
                     MarkdownTokenTypes.TEXT -> append(child.getUnescapedTextInNode(content))
+                    MarkdownTokenTypes.EMAIL_AUTOLINK -> if (child.parent == MarkdownElementTypes.LINK_TEXT) {
+                        append(child.getUnescapedTextInNode(content))
+                    } else appendEmailAutoLink(content, child, annotatorSettings)
                     GFMTokenTypes.GFM_AUTOLINK -> if (child.parent == MarkdownElementTypes.LINK_TEXT) {
                         append(child.getUnescapedTextInNode(content))
                     } else appendAutoLink(content, child, annotatorSettings)
@@ -310,8 +329,9 @@ fun AnnotatedString.Builder.buildMarkdownAnnotatedString(
                     MarkdownTokenTypes.RPAREN -> append(')')
                     MarkdownTokenTypes.LBRACKET -> append('[')
                     MarkdownTokenTypes.RBRACKET -> append(']')
-                    MarkdownTokenTypes.LT -> append('<')
-                    MarkdownTokenTypes.GT -> append('>')
+                    // Email auto-links are parsed as sibling LT, EMAIL_AUTOLINK, and GT tokens.
+                    MarkdownTokenTypes.LT -> if (children.getOrNull(index + 1)?.type != MarkdownTokenTypes.EMAIL_AUTOLINK) append('<')
+                    MarkdownTokenTypes.GT -> if (children.getOrNull(index - 1)?.type != MarkdownTokenTypes.EMAIL_AUTOLINK) append('>')
                     MarkdownTokenTypes.COLON -> append(':')
                     MarkdownTokenTypes.EXCLAMATION_MARK -> append('!')
                     MarkdownTokenTypes.BACKTICK -> append('`')

--- a/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
+++ b/multiplatform-markdown-renderer/src/commonMain/kotlin/com/mikepenz/markdown/utils/Extensions.kt
@@ -107,8 +107,8 @@ fun ASTNode.getUnescapedTextInNode(allFileText: CharSequence): String {
 /**
  * Extension function to map auto-link nodes to a specified target type.
  *
- * This function iterates over a list of `ASTNode` objects and replaces any
- * auto-link nodes (either `GFM_AUTOLINK` or `AUTOLINK`) with a new `LeafASTNode`
+ * This function iterates over a list of `ASTNode` objects and replaces
+ * `GFM_AUTOLINK`, `AUTOLINK`, and `EMAIL_AUTOLINK` nodes with a new `LeafASTNode`
  * of the specified target type. Other nodes remain unchanged.
  *
  * @param targetType The target type to map auto-link nodes to. Defaults to `MarkdownTokenTypes.TEXT`.
@@ -117,7 +117,11 @@ fun ASTNode.getUnescapedTextInNode(allFileText: CharSequence): String {
 fun List<ASTNode>.mapAutoLinkToType(targetType: IElementType = MarkdownTokenTypes.TEXT): List<ASTNode> {
     return map {
         if (it is LeafASTNode) {
-            if (it.type == GFMTokenTypes.GFM_AUTOLINK || it.type == MarkdownElementTypes.AUTOLINK) {
+            if (
+                it.type == GFMTokenTypes.GFM_AUTOLINK ||
+                it.type == MarkdownElementTypes.AUTOLINK ||
+                it.type == MarkdownTokenTypes.EMAIL_AUTOLINK
+            ) {
                 LeafASTNode(targetType, it.startOffset, it.endOffset)
             } else {
                 it

--- a/sample/shared/src/commonMain/composeResources/files/sample.md
+++ b/sample/shared/src/commonMain/composeResources/files/sample.md
@@ -99,3 +99,4 @@ Title 2
 [https://github.com/mikepenz](https://github.com/mikepenz)  
 [Mike Penz's Blog](https://blog.mikepenz.dev/)  
 <https://blog.mikepenz.dev/>  
+<opensource@mikepenz.dev>  


### PR DESCRIPTION
## Description

Render standard Markdown email autolinks such as `<user@example.com>` instead of dropping the email address.

JetBrains Markdown parses email autolinks as sibling `LT`, `EMAIL_AUTOLINK`, and `GT` tokens. This change renders the email token as a `mailto:` link while omitting the angle-bracket delimiters.

Also adds `<opensource@mikepenz.dev>` to the sample playground.

Fixes #608

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `:multiplatform-markdown-renderer:jvmTest`
- [x] `:multiplatform-markdown-renderer:apiCheck`
- [x] Manually verified email autolink rendering

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
