### PR TITLE
ci: add OpenSSF Scorecard and scope workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - '*'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   publish_archives:
     name: Publish Archives

--- a/.github/workflows/gradle-dependency-submission.yml
+++ b/.github/workflows/gradle-dependency-submission.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - develop
 
+permissions: {}
+
 jobs:
   gradle-dependency-detection:
     runs-on: ubuntu-latest

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,36 @@
+name: "Scorecard"
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '32 4 * * 1'
+  push:
+    branches: [ "develop" ]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload the SARIF results to code scanning
+      id-token: write # publish the results to the OpenSSF API (badge)
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: "Upload to code scanning"
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
     <a href="https://central.sonatype.com/artifact/com.mikepenz/multiplatform-markdown-renderer">
         <img src="https://img.shields.io/maven-central/v/com.mikepenz/multiplatform-markdown-renderer?style=flat-square&color=%231B4897"/>
     </a>
+    <a href="https://scorecard.dev/viewer/?uri=github.com/mikepenz/multiplatform-markdown-renderer">
+        <img src="https://img.shields.io/ossf-scorecard/github.com/mikepenz/multiplatform-markdown-renderer?style=flat-square&label=scorecard"/>
+    </a>
 </div>
 <br />
 


### PR DESCRIPTION
Same hardening pass as `AboutLibraries`, adapted for this repo.

### Scorecard

New `.github/workflows/scorecard.yml` — weekly, on push to `develop`, and on branch protection rule changes. `publish_results: true` feeds the OpenSSF API, so the score flows into deps.dev against the Maven coordinates; SARIF goes to code scanning so findings land in the Security tab.

`develop` is this repo's default branch — `scorecard-action` hard-fails with `only default branch is supported` anywhere else.

### Token permissions

`ci.yml` and `gradle-dependency-submission.yml` had no top-level `permissions:` block, so any job without its own inherited the full repository default token scope.

- **`ci.yml`** → top-level `contents: read`. `publish_archives` has no block of its own and inherits it; it only needs to check out, since publishing runs through external credentials (`NEXUS_*`, `SIGNING_*`) rather than the Actions token. `build` and `release` already declare their own (`contents: read` + `security-events: write` / `contents: write`), so the SARIF upload and the GitHub release upload keep the scopes they need.
- **`gradle-dependency-submission.yml`** → top-level `permissions: {}`. Its only job already declares `contents: write`.

`pr-checks.yml` and `static.yml` already had top-level blocks and are untouched.

No script injection findings here — the workflows have no untrusted input reaching a `run:` block, unlike the action repos' `commit-dist` jobs.

### Not addressed

`Signed-Releases` will stay low regardless. Scorecard reads GitHub release *assets*, and the current ones are sample app builds (`markdown-renderer-sample-v0.43.0-c4300-release.apk`/`.aab`) with no `.asc`/`.sig`/`.intoto.jsonl` beside them — the GPG signatures Maven Central requires are invisible to it.

`Code-Review` and `Branch-Protection` are repo settings rather than code, and are untouched here.