### PR TITLE
ci: attest build provenance for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
+      id-token: write # mint the Sigstore certificate for provenance
+      attestations: write # upload the attestation to the repository
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -192,6 +194,19 @@ jobs:
           ignorePreReleases: ${{ !contains(github.ref, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest build provenance
+        id: attest
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: artifacts/*
+
+      # The attestation lives in the repository store by default; Scorecard's
+      # Signed-Releases check only looks at release assets, so ship it alongside them.
+      - name: Attach provenance to the release assets
+        env:
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+        run: cp "$BUNDLE_PATH" "artifacts/multiplatform-markdown-renderer-${GITHUB_REF_NAME}.intoto.jsonl"
 
       - name: Release
         uses: mikepenz/action-gh-release@2a00e201320fb618d8e705a736286b2e31aa48e2 # v3.0.0


### PR DESCRIPTION
Applies the release-provenance half of the AboutLibraries hardening (#1442) here.

```
Signed-Releases 0  Project has not signed or included provenance with any releases.
```

Adds `actions/attest-build-provenance` to the `release` job with `id-token: write` and `attestations: write`.

The action stores the bundle in the **repository** attestation store, but Scorecard's `Signed-Releases` check only inspects **release assets** — so the bundle is copied into `artifacts/` as `.intoto.jsonl` before the release step, which already uploads `artifacts/*`.

Takes effect for future releases only; the check reads the last five, so it climbs over several releases rather than jumping at once.

## What deliberately is *not* ported from AboutLibraries

The npm dependency work does not apply here. This repo's `Vulnerabilities` check is already **10/10**, because `kotlin-js-store/` is in `.gitignore` (line 56) — there is no committed lockfile for osv-scanner to read, so none of the Kotlin/JS toolchain advisories surface.

By extension the karma removal is pointless here: it would clear nothing measurable, and this repo may have JS test sources worth keeping, so disabling browser test tasks would be a change with cost and no benefit.

Worth noting the flip side, as a separate decision rather than something this PR touches: not committing the lockfile means Kotlin/JS builds are not reproducible, and the npm tree is unpinned. AboutLibraries commits it and now scans clean at 0 advisories.

## Remaining Scorecard gaps here

Score is **7.4**. `Code-Review` (1/9 approved), `Branch-Protection`, `CII-Best-Practices` and `Fuzzing` are repository settings or separate efforts, not code changes. `Binary-Artifacts` at 9 is the `gradle-wrapper.jar`, already covered by `gradle/actions/wrapper-validation`.